### PR TITLE
Revert heap alloc, optimize 2D array, and reduce disk cache size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../lib/FiniteStateEntropy/lib
   ${CMAKE_CURRENT_SOURCE_DIR}/src
   ${CMAKE_CURRENT_SOURCE_DIR}/test
-  ${CMAKE_CURRENT_SOURCE_DIR}/hellman_example
   )
 
 add_library(fse ${FSE_FILES})
@@ -51,10 +50,6 @@ add_executable(ProofOfSpace
     src/cli.cpp
 )
 
-add_executable(HellmanAttacks
-    src/cli.cpp
-)
-
 add_executable(RunTests
     tests/test-main.cpp
     tests/test.cpp
@@ -63,16 +58,13 @@ add_executable(RunTests
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   target_link_libraries(chiapos PRIVATE fse)
   target_link_libraries(ProofOfSpace fse)
-  target_link_libraries(HellmanAttacks fse)
   target_link_libraries(RunTests fse)
 elseif (WIN32)
   target_link_libraries(chiapos PRIVATE fse)
   target_link_libraries(ProofOfSpace fse)
-  target_link_libraries(HellmanAttacks fse)
   target_link_libraries(RunTests fse)
 else()
   target_link_libraries(chiapos PRIVATE fse stdc++fs)
   target_link_libraries(ProofOfSpace fse stdc++fs)
-  target_link_libraries(HellmanAttacks fse stdc++fs)
   target_link_libraries(RunTests fse stdc++fs)
 endif()

--- a/src/bits.hpp
+++ b/src/bits.hpp
@@ -248,10 +248,12 @@ template <class T> class BitsGeneric {
         if (values_[values_.size() - 1] != last_bucket_mask) {
             values_[values_.size() - 1]++;
         } else {
+            bool all_one = true;
             if (values_.size() > 1) {
                 // Otherwise, search for the first bucket that isn't full of 1 bits.
                 for (int16_t i = values_.size() - 2; i >= 0; i--)
                     if (values_[i] != limit) {
+                        all_one = false;
                         // Increment it.
                         values_[i]++;
                         // Buckets that were full of 1 bits turn all to 0 bits.

--- a/src/bits.hpp
+++ b/src/bits.hpp
@@ -21,11 +21,8 @@
 #include <string>
 #include <utility>
 #include "./util.hpp"
-#include <functional>
-#include <memory>
-#include <iostream>
+#include "./stack_allocator.h"
 
-using namespace std;
 
 #define kBufSize 5
 
@@ -36,21 +33,8 @@ using namespace std;
 struct SmallVector {
     typedef uint16_t size_type;
 
-    SmallVector() {
-        v_ = new uint128_t[5];
+    SmallVector() noexcept {
         count_ = 0;
-    }
-
-    SmallVector(const SmallVector &other)
-    {
-        v_ = new uint128_t[5];
-        count_=other.count_;
-        for (size_type i = 0; i < other.count_; i++)
-            v_[i] = other.v_[i];
-    }
-
-    ~SmallVector() {
-        delete[] v_;
     }
 
     uint128_t& operator[] (const uint16_t index) {
@@ -77,7 +61,7 @@ struct SmallVector {
     }
 
  private:
-    uint128_t *v_;
+    uint128_t v_[5];
     size_type count_;
 };
 
@@ -87,21 +71,8 @@ struct SmallVector {
 struct ParkVector {
     typedef uint32_t size_type;
 
-    ParkVector() {
-        v_ = new uint128_t[1024];
+    ParkVector() noexcept {
         count_ = 0;
-    }
-
-    ParkVector(const ParkVector &other)
-    {
-        v_ = new uint128_t[1024];
-        count_=other.count_;
-        for (size_type i = 0; i < other.count_; i++)
-            v_[i] = other.v_[i];
-    }
-
-    ~ParkVector() {
-        delete[] v_;
     }
 
     uint128_t& operator[] (const uint32_t index) {
@@ -128,7 +99,7 @@ struct ParkVector {
     }
 
  private:
-    uint128_t *v_;
+    uint128_t v_[1024];
     size_type count_;
 };
 
@@ -267,7 +238,7 @@ template <class T> class BitsGeneric {
             this->AppendValue(b.values_[b.values_.size() - 1], b.last_size_);
         }
         return *this;
-    }  
+    }
 
     BitsGeneric<T>& operator++() {
         uint128_t limit = ((uint128_t)std::numeric_limits<uint64_t> :: max() << 64) +
@@ -309,7 +280,7 @@ template <class T> class BitsGeneric {
             values_[values_.size() - 1]--;
             return *this;
         }
-        
+
         if (values_.size() > 1) {
             // Search for the first bucket different than 0.
             for (int16_t i = values_.size() - 2; i >= 0; i--)

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -1007,7 +1007,7 @@ class DiskPlotter {
             bool should_read_entry = true;
             std::vector<uint64_t> left_new_pos(kCachedPositionsSize);
 
-            Bits old_sort_keys[kReadMinusWrite][kMaxMatchesSingleEntry];
+            uint64_t old_sort_keys[kReadMinusWrite][kMaxMatchesSingleEntry];
             uint64_t old_offsets[kReadMinusWrite][kMaxMatchesSingleEntry];
             uint16_t old_counters[kReadMinusWrite];
             for (uint32_t i = 0; i < kReadMinusWrite; i++) {
@@ -1061,7 +1061,7 @@ class DiskPlotter {
                         } else if (entry_pos == current_pos) {
                             uint64_t old_write_pos = entry_pos % kReadMinusWrite;
                             old_sort_keys[old_write_pos][old_counters[old_write_pos]]
-                                = Bits(entry_sort_key, right_sort_key_size);
+                                = entry_sort_key;
                             old_offsets[old_write_pos][old_counters[old_write_pos]] = (entry_pos + entry_offset);
                             ++old_counters[old_write_pos];
                         } else {
@@ -1110,7 +1110,7 @@ class DiskPlotter {
                             }
                         }
                         Bits to_write = Bits(line_point, 2*k);
-                        to_write += old_sort_keys[write_pointer_pos % kReadMinusWrite][counter];
+                        to_write += Bits(old_sort_keys[write_pointer_pos % kReadMinusWrite][counter], right_sort_key_size);
 
                         to_write.ToBytes(right_entry_buf);
                         right_writer.write((const char*)right_entry_buf, right_entry_size_bytes);

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -664,17 +664,9 @@ class DiskPlotter {
             // Sort keys represent the ordering of entries, sorted by (y, pos, offset),
             // but using less bits (only k+1 instead of 2k + 9, etc.)
             // This is a map from old position to array of sort keys (one for each R entry with this pos)
-            //Bits old_sort_keys[kReadMinusWrite][kMaxMatchesSingleEntry];
-            Bits **old_sort_keys = new Bits*[kReadMinusWrite];
-            for(int i = 0; i < kReadMinusWrite; ++i) {
-                old_sort_keys[i] = new Bits[kMaxMatchesSingleEntry];
-            }
+            uint64_t old_sort_keys[kReadMinusWrite][kMaxMatchesSingleEntry];
             // Map from old position to other positions that it matches with
-            //uint64_t old_offsets[kReadMinusWrite][kMaxMatchesSingleEntry];
-            uint64_t **old_offsets = new uint64_t*[kReadMinusWrite];
-            for(int i = 0; i < kReadMinusWrite; ++i) {
-                old_offsets[i] = new uint64_t[kMaxMatchesSingleEntry];
-            }
+            uint64_t old_offsets[kReadMinusWrite][kMaxMatchesSingleEntry];
             // Map from old position to count (number of times it appears)
             uint16_t old_counters[kReadMinusWrite];
 
@@ -765,13 +757,10 @@ class DiskPlotter {
                             used_positions[(entry_pos + entry_offset) % kCachedPositionsSize] = true;
 
                             uint64_t old_write_pos = entry_pos % kReadMinusWrite;
-                            if (table_index == 7) {
-                                // Stores the sort key for this R entry, which is just y (so k bits)
-                                old_sort_keys[old_write_pos][old_counters[old_write_pos]] = Bits(entry_sort_key, k);
-                            } else {
-                                // Stores the sort key for this R entry
-                                old_sort_keys[old_write_pos][old_counters[old_write_pos]] = Bits(entry_sort_key, k + 1);
-                            }
+
+                            // Stores the sort key for this R entry
+                            old_sort_keys[old_write_pos][old_counters[old_write_pos]] = entry_sort_key;
+
                             // Stores the other matching pos for this R entry (pos6 + offset)
                             old_offsets[old_write_pos][old_counters[old_write_pos]] = entry_pos + entry_offset;
                             ++old_counters[old_write_pos];
@@ -850,8 +839,8 @@ class DiskPlotter {
                         // Creates and writes the new right entry, with the cached data
                         uint64_t new_offset_pos = new_positions[old_offsets[write_pointer_pos % kReadMinusWrite]
                                                                 [counter] % kCachedPositionsSize];
-
-                        Bits& new_right_entry = old_sort_keys[write_pointer_pos % kReadMinusWrite][counter];
+                        Bits new_right_entry = table_index == 7 ? Bits(old_sort_keys[write_pointer_pos % kReadMinusWrite][counter], k) :
+                                                                  Bits(old_sort_keys[write_pointer_pos % kReadMinusWrite][counter], k + 1);
                         new_right_entry += new_pos_bin;
                         //match_positions.push_back(std::make_pair(new_pos, new_offset_pos));
                         new_right_entry.AppendValue(new_offset_pos - new_pos, kOffsetSize);
@@ -885,16 +874,6 @@ class DiskPlotter {
             delete[] left_entry_buf;
             delete[] new_left_entry_buf;
             delete[] right_entry_buf;
-
-            for(int i = 0; i < kReadMinusWrite; ++i) {
-                delete [] old_offsets[i];
-            }
-            delete [] old_offsets;
-
-            for(int i = 0; i < kReadMinusWrite; ++i) {
-                delete [] old_sort_keys[i];
-            }
-            delete [] old_sort_keys;
         }
         delete[] memory;
     }

--- a/src/sort_on_disk.hpp
+++ b/src/sort_on_disk.hpp
@@ -15,7 +15,7 @@
 #ifndef SRC_CPP_SORT_ON_DISK_HPP_
 #define SRC_CPP_SORT_ON_DISK_HPP_
 
-#define BUF_SIZE 262144
+#define BUF_SIZE 65536
 
 #include <vector>
 #include <iostream>
@@ -31,10 +31,21 @@ class SortOnDiskUtils {
      * index, to the given index.
      */
     inline static uint64_t ExtractNum(uint8_t* bytes, uint32_t len_bytes, uint32_t begin_bits, uint32_t take_bits) {
+        uint32_t start_index = begin_bits / 8;
+        uint32_t end_index;
         if ((begin_bits + take_bits) / 8 > len_bytes - 1) {
-            take_bits = len_bytes * 8 - begin_bits;
+            take_bits = (len_bytes) * 8 - begin_bits;
         }
-        return Util::SliceInt64FromBytes(bytes, len_bytes, begin_bits, take_bits);
+        end_index = (begin_bits + take_bits) / 8;
+
+        assert(take_bits <= 64);
+        uint64_t sum = bytes[start_index] & ((1 << (8 - (begin_bits % 8))) - 1);
+        for (uint32_t i = start_index + 1; i <= end_index; i++) {
+            sum = (sum << 8);
+            if(i < len_bytes) // Fix to prevent overflow and maintain compatibility. Function may only return 57 bits in some cases
+                sum += bytes[i];
+        }
+        return sum >> (8 - ((begin_bits + take_bits) % 8));
     }
 
     /*
@@ -81,13 +92,8 @@ class Disk {
 
 class FileDisk : public Disk {
  public:
-    FileDisk(const std::string& filename) {
-        buf_ = new char[BUF_SIZE];
+    inline explicit FileDisk(const std::string& filename) {
         Initialize(filename);
-    }
-
-    ~FileDisk() {
-        delete[] buf_;
     }
 
     inline void Close() {
@@ -147,7 +153,7 @@ class FileDisk : public Disk {
     }
 
     std::string filename_;
-    char *buf_;
+    char buf_[BUF_SIZE];
     std::fstream f_;
 };
 


### PR DESCRIPTION
Please do not merge yet. This is still in progress.

1. Decrease 2D array size: It's only storing stuff up to k+1 bits (less than 64 bits) so we don't need to create a Bits object, can store uint64 instead. That decreases it from 4.5MB to 450KB.
2. Decrease write buffer from 256KB to 64 KB
3. Reverts ExtractNum to the version which is compatible, but fixed buffer overflow.
4. Go back to stack allocation to bring speed back to normal