### PR TITLE
Add compile and test for windows but not wheel builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        os: [macos-latest, ubuntu-18.04] # windows-latest doesn't work yet
-        os: [windows-latest] # windows-latest doesn't work yet
+        os: [macos-latest, ubuntu-18.04, windows-latest] # windows-latest doesn't work yet
+#        os: [windows-latest] # windows-latest doesn't work yet
 
     steps:
     - uses: actions/checkout@v1
@@ -40,7 +40,7 @@ jobs:
         msys2do pacman -S --noconfirm mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-gmp mingw-w64-x86_64-dlib mingw-w64-x86_64-python-pep517 mingw-w64-x86_64-python-pytest mingw-w64-x86_64-python-pip git
         msys2do ./windows-build.sh
 
-    - name: Build source distribution
+    - name: Build source distribution with MacOS
       if: startsWith(matrix.os, 'mac')
       run: |
         pip install pep517
@@ -59,7 +59,7 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
         CIBW_BEFORE_BUILD_LINUX: curl -L https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-`uname -m`.sh > cmake.sh && yes | sh cmake.sh | cat && rm -f /usr/bin/cmake && yum -y install boost-devel gmp-devel && python -m pip install --upgrade pip && which cmake && cmake --version
         CIBW_BEFORE_BUILD_MACOS: brew install boost && python -m pip install --upgrade pip
-        CIBW_BEFORE_BUILD_WINDOWS: python -m pip install --upgrade pip
+        #CIBW_BEFORE_BUILD_WINDOWS: python -m pip install --upgrade pip
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: py.test -v {project}/tests
         CIBW_ENVIRONMENT_LINUX: "PATH=/project/cmake-3.17.0-Linux-`uname -m`/bin:$PATH BUILD_VDF_CLIENT=N"
@@ -81,10 +81,11 @@ jobs:
         TWINE_NON_INTERACTIVE: 1
         TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
       run: twine upload --non-interactive --skip-existing --verbose 'dist/*'
-#    - name: Publish distribution to PyPI
-#      if: startsWith(github.event.ref, 'refs/tags')
-#      env:
-#        TWINE_USERNAME: __token__
-#        TWINE_NON_INTERACTIVE: 1
-#        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-#      run: twine upload --non-interactive --skip-existing --verbose 'dist/*'
+    - name: Publish distribution to PyPI
+      if: startsWith(github.event.ref, 'refs/tags')
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_NON_INTERACTIVE: 1
+        TWINE_PASSWORD: ${{ secrets.pypi_password }}
+      run: twine upload --non-interactive --skip-existing --verbose 'dist/*'
+      if: "!startsWith(matrix.os, 'windows')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         name: wheels
         path: ./dist
     - name: Install twine
-      if: "!startsWith(matrix.os, 'windows')"
+      if: !startsWith(matrix.os, 'windows')
       run: pip install twine
     - name: Publish distribution to Test PyPI
       if: "!startsWith(matrix.os, 'windows')"
@@ -82,7 +82,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
       run: twine upload --non-interactive --skip-existing --verbose 'dist/*'
     - name: Publish distribution to PyPI
-      if: startsWith(github.event.ref, 'refs/tags') && "!startsWith(matrix.os, 'windows')"
+      if: startsWith(github.event.ref, 'refs/tags') && !startsWith(matrix.os, 'windows')
       env:
         TWINE_USERNAME: __token__
         TWINE_NON_INTERACTIVE: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-18.04] # windows-latest doesn't work yet
+#        os: [macos-latest, ubuntu-18.04] # windows-latest doesn't work yet
+        os: [windows-latest] # windows-latest doesn't work yet
 
     steps:
     - uses: actions/checkout@v1
@@ -17,27 +18,27 @@ jobs:
         fetch-depth: 0
         # we need fetch-depth 0 so setuptools_scm can resolve tags
     - uses: actions/setup-python@v1
+      if: "!startsWith(matrix.os, 'windows')"
       name: Install Python
       with:
         python-version: '3.7'
 
     - name: Install cibuildwheel
+      if: "!startsWith(matrix.os, 'windows')"
       run: |
         python -m pip install cibuildwheel==1.3.0
 
-    - name: Setup cmake
-      # for whatever reason, Windows can't find the cmake installed by python
-      # we will hack around it for now
+    - name: Prepare Windows Build environment
       if: startsWith(matrix.os, 'windows')
-      uses: jwlawson/actions-setup-cmake@v1.0
+      uses: numworks/setup-msys2@v1
       with:
-        cmake-version: '3.16.3'
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+        update: true
 
-    - name: Install Visual C++ for Python 2.7
+    - name: Windows install dependencies and build
       if: startsWith(matrix.os, 'windows')
       run: |
-        choco install vcpython27 -f -y
+        msys2do pacman -S --noconfirm mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-gmp mingw-w64-x86_64-dlib mingw-w64-x86_64-python-pep517 mingw-w64-x86_64-python-pytest mingw-w64-x86_64-python-pip git
+        msys2do ./windows-build.sh
 
     - name: Build source distribution
       if: startsWith(matrix.os, 'mac')
@@ -46,6 +47,7 @@ jobs:
         python -m pep517.build --source --out-dir dist .
 
     - name: Build wheel
+      if: "!startsWith(matrix.os, 'windows')"
       run: |
         python -m cibuildwheel --output-dir dist
       env:
@@ -63,23 +65,26 @@ jobs:
         CIBW_ENVIRONMENT_LINUX: "PATH=/project/cmake-3.17.0-Linux-`uname -m`/bin:$PATH BUILD_VDF_CLIENT=N"
 
     - name: Upload artifacts
+      if: "!startsWith(matrix.os, 'windows')"
       uses: actions/upload-artifact@v1
       with:
         name: wheels
         path: ./dist
     - name: Install twine
+      if: "!startsWith(matrix.os, 'windows')"
       run: pip install twine
     - name: Publish distribution to Test PyPI
+      if: "!startsWith(matrix.os, 'windows')"
       env:
         TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
         TWINE_USERNAME: __token__
         TWINE_NON_INTERACTIVE: 1
         TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
       run: twine upload --non-interactive --skip-existing --verbose 'dist/*'
-    - name: Publish distribution to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      run: twine upload --non-interactive --skip-existing --verbose 'dist/*'
+#    - name: Publish distribution to PyPI
+#      if: startsWith(github.event.ref, 'refs/tags')
+#      env:
+#        TWINE_USERNAME: __token__
+#        TWINE_NON_INTERACTIVE: 1
+#        TWINE_PASSWORD: ${{ secrets.pypi_password }}
+#      run: twine upload --non-interactive --skip-existing --verbose 'dist/*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,10 +82,9 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
       run: twine upload --non-interactive --skip-existing --verbose 'dist/*'
     - name: Publish distribution to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
+      if: startsWith(github.event.ref, 'refs/tags') && "!startsWith(matrix.os, 'windows')"
       env:
         TWINE_USERNAME: __token__
         TWINE_NON_INTERACTIVE: 1
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: twine upload --non-interactive --skip-existing --verbose 'dist/*'
-      if: "!startsWith(matrix.os, 'windows')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         name: wheels
         path: ./dist
     - name: Install twine
-      if: !startsWith(matrix.os, 'windows')
+      if: "!startsWith(matrix.os, 'windows')"
       run: pip install twine
     - name: Publish distribution to Test PyPI
       if: "!startsWith(matrix.os, 'windows')"

--- a/windows-build.sh
+++ b/windows-build.sh
@@ -20,9 +20,8 @@ make
 echo "Running RunTests.exe"
 $PWD/RunTests.exe
 
-echo "Not Running py.test -v tests/"
-#Test failing for windows:
-#py.test -v $PWD/tests/
+echo "Running py.test -v tests/"
+py.test -v $PWD/tests/
 
-echo "Done because we can't build wheels yet."
-#pip -vv wheel .
+echo "Trying to build a wheel"
+pip -vv wheel .

--- a/windows-build.sh
+++ b/windows-build.sh
@@ -3,22 +3,26 @@
 # Stop in case of error
 set -e
 
-#python -m pip install cibuildwheel==1.3.0
+export CMAKE_GENERATOR='MSYS Makefiles'
 
+#export PATH=$PATH:"C:\msys64\mingw64\bin"
+echo "PATH is $PATH"
 
-# build just python 3.7
-export CIBW_BUILD="cp37-win_amd64"
-#export CIBW_BEFORE_BUILD_WINDOWS="python -m pip install --upgrade pip"
-export CIBW_TEST_REQUIRES="pytest"
-export CIBW_TEST_COMMAND="py.test -v {project}/tests"
-
-
-export PATH=$PATH:"C:\msys64\mingw64\bin\cmake.exe"
 echo "PWD is $PWD"
 
+#python3 -m venv venv
+#. venv/bin/activate
+
+#pip wheel . -G "MSYS Makefiles"
 cmake -G "MSYS Makefiles" --build .
 make
+
+echo "Running RunTests.exe"
 $PWD/RunTests.exe
+
+echo "Not Running py.test -v tests/"
 #Test failing for windows:
-py.test -v $PWD/tests/
+#py.test -v $PWD/tests/
+
+echo "Done because we can't build wheels yet."
 #pip -vv wheel .

--- a/windows-build.sh
+++ b/windows-build.sh
@@ -23,5 +23,6 @@ $PWD/RunTests.exe
 echo "Running py.test -v tests/"
 py.test -v $PWD/tests/
 
-echo "Trying to build a wheel"
-pip -vv wheel .
+echo "Testing Windows Complete"
+#echo "Trying to build a wheel"
+#pip -vv wheel .


### PR DESCRIPTION
This will serve as a ci for all three platforms while only building src, mac, and ubuntu wheels until we can get windows to wheel.