### PR TITLE
Remove vcpython27 as superfluous 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,10 @@ jobs:
         pip install pep517
         python -m pep517.build --source --out-dir dist .
 
-    - name: Install Visual C++ for Python 2.7
-      if: startsWith(matrix.os, 'windows')
-      run: |
-        choco install vcpython27 -f -y
+    #- name: Install Visual C++ for Python 2.7
+      #if: startsWith(matrix.os, 'windows')
+      #run: |
+        #choco install vcpython27 -f -y
     - name: Build wheel
       run: |
         python -m cibuildwheel --output-dir dist
@@ -79,5 +79,3 @@ jobs:
         TWINE_NON_INTERACTIVE: 1
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: twine upload --non-interactive --skip-existing --verbose 'dist/*whl'
-
-


### PR DESCRIPTION
vcpython27 isn't needed to build windows wheels here.