### PR TITLE
128wjb

### DIFF
--- a/src/bits.hpp
+++ b/src/bits.hpp
@@ -21,12 +21,10 @@
 #include <string>
 #include <utility>
 #include "./util.hpp"
-#include "./stack_allocator.h"
 
+using namespace std;
 
-#define kBufSize 5
-
-// 128 * 2^16. 2^16 values, each value can store 128 bits.
+// 64 * 2^16. 2^17 values, each value can store 64 bits.
 #define kMaxSizeBits 8388608
 
 // A stack vector of length 5, having the functions of std::vector needed for Bits.
@@ -37,15 +35,15 @@ struct SmallVector {
         count_ = 0;
     }
 
-    uint128_t& operator[] (const uint16_t index) {
+    uint64_t& operator[] (const uint16_t index) {
         return v_[index];
     }
 
-    uint128_t operator[] (const uint16_t index) const {
+    uint64_t operator[] (const uint16_t index) const {
         return v_[index];
     }
 
-    void push_back(uint128_t value) {
+    void push_back(uint64_t value) {
         v_[count_++] = value;
     }
 
@@ -61,13 +59,13 @@ struct SmallVector {
     }
 
  private:
-    uint128_t v_[5];
+    uint64_t v_[10];
     size_type count_;
 };
 
 
 // A stack vector of length 1024, having the functions of std::vector needed for Bits.
-// The max number of Bits that can be stored is 1024 * 128
+// The max number of Bits that can be stored is 1024 * 64
 struct ParkVector {
     typedef uint32_t size_type;
 
@@ -75,15 +73,15 @@ struct ParkVector {
         count_ = 0;
     }
 
-    uint128_t& operator[] (const uint32_t index) {
+    uint64_t& operator[] (const uint32_t index) {
         return v_[index];
     }
 
-    uint128_t operator[] (const uint32_t index) const {
+    uint64_t operator[] (const uint32_t index) const {
         return v_[index];
     }
 
-    void push_back(uint128_t value) {
+    void push_back(uint64_t value) {
         v_[count_++] = value;
     }
 
@@ -99,7 +97,7 @@ struct ParkVector {
     }
 
  private:
-    uint128_t v_[1024];
+    uint64_t v_[2048];
     size_type count_;
 };
 
@@ -108,7 +106,7 @@ struct ParkVector {
  * array of integers, allowing for efficient bit manipulations. The Bits class provides
  * utilities to easily work with Bits, adding and slicing them, etc.
  * The class is a generic one, allowing any type of an array, as long as providing std::vector methods.
- * We currently use SmallVector (stack-array of length 5), ParkVector (stack-array of length 128) and
+ * We currently use SmallVector (stack-array of length 10), ParkVector (stack-array of length 2048) and
  * std::vector.
  * Conversion between two BitsGeneric<T> classes of different types can be done by using += operator, or converting
  * to bytes the first class, then using the bytes constructor of the second class (should be slower).
@@ -124,23 +122,30 @@ template <class T> class BitsGeneric {
         this->last_size_ = 0;
     }
 
-
-    // Converts from unit128_t to Bits. If the number of bits of value is smaller than size, adds 0 bits at the beginning.
+    // Converts from unit64_t to Bits. If the number of bits of value is smaller than size, adds 0 bits at the beginning.
     // i.e. Bits(5, 10) = 0000000101
     BitsGeneric<T>(uint128_t value, uint32_t size) {
-        // TODO(mariano) remove
-        if (size < 128 && value > ((uint128_t)1 << size)) {
-            std::cout << "TOO BIG FOR BITS" << std::endl;
-            // abort();
+        if (size > 64) {
+            //std::cout << "SPLITTING BitsGeneric" << std::endl;
+            InitBitsGeneric(value>>64,size-64);
+            AppendValue((uint64_t)value,64);
         }
+        else{
+            InitBitsGeneric((uint64_t)value,size);
+        }
+    }
+    
+    // Converts from unit64_t to Bits. If the number of bits of value is smaller than size, adds 0 bits at the beginning.
+    // i.e. Bits(5, 10) = 0000000101
+    void InitBitsGeneric(uint64_t value, uint32_t size) {
         this->last_size_ = 0;
-        if (size > 128) {
+        if (size > 64) {
             // Get number of extra 0s added at the beginning.
             uint32_t zeros = size - Util::GetSizeBits(value);
-            // Add a full group of 0s (length 128)
-            while (zeros > 128) {
-                AppendValue(0, 128);
-                zeros -= 128;
+            // Add a full group of 0s (length 64)
+            while (zeros > 64) {
+                AppendValue(0, 64);
+                zeros -= 64;
             }
             // Add the incomplete group of 0s and then the value.
             AppendValue(0, zeros);
@@ -159,16 +164,16 @@ template <class T> class BitsGeneric {
         assert(size >= total_size);
         // Add the extra 0 bits at the beginning.
         uint32_t extra_space = size - total_size;
-        while (extra_space >= 128) {
-            AppendValue(0, 128);
-            extra_space -= 128;
+        while (extra_space >= 64) {
+            AppendValue(0, 64);
+            extra_space -= 64;
         }
         if (extra_space > 0)
             AppendValue(0, extra_space);
         // Copy the Bits object element by element, and append it to the current Bits object.
         if (other.values_.size() > 0) {
             for (uint32_t i = 0; i < other.values_.size() - 1; i++)
-                AppendValue(other.values_[i], 128);
+                AppendValue(other.values_[i], 64);
             AppendValue(other.values_[other.values_.size() - 1], other.last_size_);
         }
     }
@@ -178,19 +183,19 @@ template <class T> class BitsGeneric {
         this->last_size_ = 0;
         uint32_t extra_space = size_bits - num_bytes * 8;
         // Add the extra 0 bits at the beginning.
-        while (extra_space >= 128) {
-            AppendValue(0, 128);
-            extra_space -= 128;
+        while (extra_space >= 64) {
+            AppendValue(0, 64);
+            extra_space -= 64;
         }
         if (extra_space > 0) {
             AppendValue(0, extra_space);
         }
-        for (uint32_t i = 0; i < num_bytes; i += 16) {
-            uint128_t val = 0;
+        for (uint32_t i = 0; i < num_bytes; i += sizeof(uint64_t)/sizeof(uint8_t)) {
+            uint64_t val = 0;
             uint8_t bucket_size = 0;
-            // Compress bytes together into uint128_t, either until we have 128 bits, or until we run out of bytes
+            // Compress bytes together into uint64_t, either until we have 64 bits, or until we run out of bytes
             // in big_endian_bytes.
-            for (uint32_t j = i; j < i + 16 && j < num_bytes; j++) {
+            for (uint32_t j = i; j < i + sizeof(uint64_t)/sizeof(uint8_t) && j < num_bytes; j++) {
                 val = (val << 8) + big_endian_bytes[j];
                 bucket_size += 8;
             }
@@ -218,12 +223,12 @@ template <class T> class BitsGeneric {
         BitsGeneric<T> result;
         if (values_.size() > 0) {
             for (typename T::size_type i = 0; i < values_.size() - 1; i++)
-                result.AppendValue(values_[i], 128);
+                result.AppendValue(values_[i], 64);
             result.AppendValue(values_[values_.size() - 1], last_size_);
         }
         if (b.values_.size() > 0) {
             for (typename T::size_type i = 0; i < b.values_.size() - 1; i++)
-                result.AppendValue(b.values_[i], 128);
+                result.AppendValue(b.values_[i], 64);
             result.AppendValue(b.values_[b.values_.size() - 1], b.last_size_);
         }
         return result;
@@ -234,16 +239,16 @@ template <class T> class BitsGeneric {
     BitsGeneric<T>& operator += (const BitsGeneric<T2>& b) {
         if (b.values_.size() > 0) {
              for (typename T2::size_type i = 0; i < b.values_.size() - 1; i++)
-                this->AppendValue(b.values_[i], 128);
+                this->AppendValue(b.values_[i], 64);
             this->AppendValue(b.values_[b.values_.size() - 1], b.last_size_);
         }
         return *this;
     }
 
     BitsGeneric<T>& operator++() {
-        uint128_t limit = ((uint128_t)std::numeric_limits<uint64_t> :: max() << 64) +
-                          (uint128_t)std::numeric_limits<uint64_t> :: max();
-        uint128_t last_bucket_mask = (last_size_ == 128) ? limit : ((static_cast<uint128_t>(1) << last_size_) - 1);
+        uint64_t limit = ((uint64_t)std::numeric_limits<uint32_t> :: max() << 32) +
+                          (uint64_t)std::numeric_limits<uint32_t> :: max();
+        uint64_t last_bucket_mask = (last_size_ == 64) ? limit : ((static_cast<uint64_t>(1) << last_size_) - 1);
         // If the last bucket isn't full of 1 bits, we can increment that by one.
         if (values_[values_.size() - 1] != last_bucket_mask) {
             values_[values_.size() - 1]++;
@@ -290,14 +295,14 @@ template <class T> class BitsGeneric {
                     all_zero = false;
                     // Decrement it.
                     values_[i]--;
-                    uint128_t limit = ((uint128_t)std::numeric_limits<uint64_t> :: max() << 64) +
-                                      (uint128_t)std::numeric_limits<uint64_t> :: max();
+                    uint64_t limit = ((uint64_t)std::numeric_limits<uint32_t> :: max() << 32) +
+                                      (uint64_t)std::numeric_limits<uint32_t> :: max();
                     // All buckets that were previously 0, now become full of 1s.
                     // (i.e. 1010000 - 1 = 1001111)
                     for (typename T::size_type j = i + 1; j < values_.size() - 1; j++)
                         values_[j] =  limit;
-                    values_[values_.size() - 1] = (last_size_ == 128) ? limit :
-                                                   ((static_cast<uint128_t>(1) << last_size_) - 1);
+                    values_[values_.size() - 1] = (last_size_ == 64) ? limit :
+                                                   ((static_cast<uint64_t>(1) << last_size_) - 1);
                     break;
                 }
         }
@@ -335,33 +340,33 @@ template <class T> class BitsGeneric {
 
         if (end_index == start_index) return BitsGeneric<T>();
         assert(end_index > start_index);
-        uint32_t start_bucket = start_index / 128;
-        uint32_t end_bucket = end_index / 128;
+        uint32_t start_bucket = start_index / 64;
+        uint32_t end_bucket = end_index / 64;
         if (start_bucket == end_bucket) {
             // Positions inside the bucket.
-            start_index = start_index % 128;
-            end_index = end_index % 128;
-            uint8_t bucket_size = ((int)start_bucket == (int)(values_.size() - 1)) ? last_size_ : 128;
-            uint128_t val = values_[start_bucket];
+            start_index = start_index % 64;
+            end_index = end_index % 64;
+            uint8_t bucket_size = ((int)start_bucket == (int)(values_.size() - 1)) ? last_size_ : 64;
+            uint64_t val = values_[start_bucket];
             // Cut the prefix [0, start_index)
             if (start_index != 0)
-                val = val & ((static_cast<uint128_t>(1) << (bucket_size - start_index)) - 1);
+                val = val & ((static_cast<uint64_t>(1) << (bucket_size - start_index)) - 1);
             // Cut the suffix after end_index
             val = val >> (bucket_size - end_index);
             return BitsGeneric<T>(val, end_index - start_index);
         } else {
             BitsGeneric<T> result;
-            uint128_t prefix, suffix;
+            uint64_t prefix, suffix;
             // Get the prefix from the last bucket.
-            SplitNumberByPrefix(values_[start_bucket], 128, start_index % 128, &prefix, &suffix);
-            result.AppendValue(suffix, 128 - start_index % 128);
+            SplitNumberByPrefix(values_[start_bucket], 64, start_index % 64, &prefix, &suffix);
+            result.AppendValue(suffix, 64 - start_index % 64);
             // Append all the in between buckets
             for (uint32_t i = start_bucket + 1; i < end_bucket; i++)
-                result.AppendValue(values_[i], 128);
-            uint8_t bucket_size = ((int)end_bucket == (int)(values_.size() - 1)) ? last_size_ : 128;
+                result.AppendValue(values_[i], 64);
+            uint8_t bucket_size = ((int)end_bucket == (int)(values_.size() - 1)) ? last_size_ : 64;
             // Get the suffix from the last bucket.
-            SplitNumberByPrefix(values_[end_bucket], bucket_size, end_index % 128, &prefix, &suffix);
-            result.AppendValue(prefix, end_index % 128);
+            SplitNumberByPrefix(values_[end_bucket], bucket_size, end_index % 64, &prefix, &suffix);
+            result.AppendValue(prefix, end_index % 64);
             return result;
         }
     }
@@ -374,22 +379,22 @@ template <class T> class BitsGeneric {
         if (start_index < 0) {
             start_index = 0;
         } */
-        if ((start_index >> 7) == (end_index >> 7)) {
-            uint128_t res = values_[start_index >> 7];
-            if ((start_index >> 7) == values_.size() - 1)
-                res = res >> (last_size_ - (end_index & 127));
+        if ((start_index >> 6) == (end_index >> 6)) {
+            uint64_t res = values_[start_index >> 6];
+            if ((start_index >> 6) == values_.size() - 1)
+                res = res >> (last_size_ - (end_index & 63));
             else
-                res = res >> (128 - (end_index & 127));
-            res = res & (((uint128_t)1 << ((end_index & 127) - (start_index & 127))) - 1);
+                res = res >> (64 - (end_index & 63));
+            res = res & (((uint64_t)1 << ((end_index & 63) - (start_index & 63))) - 1);
             return res;
         } else {
-            assert((start_index >> 7) + 1 == (end_index >> 7));
-            uint128_t prefix, suffix;
-            SplitNumberByPrefix(values_[(start_index >> 7)], 128, start_index & 127, &prefix, &suffix);
-            uint128_t result = suffix;
-            uint8_t bucket_size = ((end_index >> 7) == values_.size() - 1) ? last_size_ : 128;
-            SplitNumberByPrefix(values_[(end_index >> 7)], bucket_size, end_index & 127, &prefix, &suffix);
-            result = (result << (end_index & 127)) + prefix;
+            assert((start_index >> 6) + 1 == (end_index >> 6));
+            uint64_t prefix, suffix;
+            SplitNumberByPrefix(values_[(start_index >> 6)], 64, start_index & 63, &prefix, &suffix);
+            uint64_t result = suffix;
+            uint8_t bucket_size = ((end_index >> 6) == values_.size() - 1) ? last_size_ : 64;
+            SplitNumberByPrefix(values_[(end_index >> 6)], bucket_size, end_index & 63, &prefix, &suffix);
+            result = (result << (end_index & 63)) + prefix;
             return result;
         }
     }
@@ -401,7 +406,7 @@ template <class T> class BitsGeneric {
 
         // Append 0s to complete the last byte.
         uint8_t shift = Util::ByteAlign(last_size_) - last_size_;
-        uint128_t val = values_[values_.size() - 1] << (shift);
+        uint64_t val = values_[values_.size() - 1] << (shift);
         uint32_t cnt = 0;
         // Extract byte-by-byte from the last bucket.
         uint8_t iterations = last_size_ / 8;
@@ -414,8 +419,8 @@ template <class T> class BitsGeneric {
         // Extract the full buckets, byte by byte.
         if (values_.size() >= 2) {
             for (int32_t i = values_.size() - 2; i >= 0; i--) {
-                uint128_t val = values_[i];
-                for (uint8_t j = 0; j < 16; j++) {
+                uint64_t val = values_[i];
+                for (uint8_t j = 0; j < sizeof(uint64_t)/sizeof(uint8_t); j++) {
                     buffer[cnt++] = (val & 0xff);
                     val >>= 8;
                 }
@@ -436,8 +441,8 @@ template <class T> class BitsGeneric {
     std::string ToString() const {
         std::string str = "";
         for (typename T::size_type i = 0; i < values_.size(); i++) {
-            uint128_t val = values_[i];
-            typename T::size_type size = (i == values_.size() - 1) ? last_size_ : 128;
+            uint64_t val = values_[i];
+            typename T::size_type size = (i == values_.size() - 1) ? last_size_ : 64;
             std::string str_bucket = "";
             for (typename T::size_type i = 0; i < size; i++) {
                 if (val % 2)
@@ -451,36 +456,47 @@ template <class T> class BitsGeneric {
         return str;
     }
 
-    // If the bitarray fits into 128 bits, returns it as an uint128_t, otherwise throws error
-    uint128_t GetValue() const {
+    // If the bitarray fits into 64 bits, returns it as an uint64_t, otherwise throws error
+    uint64_t GetValue() const {
         if (values_.size() != 1) {
             std::cout << "Number of values is: " << values_.size() << std::endl;
             std::cout << "Size of bits is: " << GetSize() << std::endl;
-            throw std::string("Number doesn't fit into a 128-bit type.");
+            throw std::string("Number doesn't fit into a 64-bit type.");
         }
         return values_[0];
     }
 
     uint32_t GetSize() const {
         if (values_.size() == 0) return 0;
-        // Full buckets contain each 128 bits, last one contains only 'last_size_' bits.
-        return ((uint32_t)values_.size() - 1) * 128 + last_size_;
+        // Full buckets contain each 64 bits, last one contains only 'last_size_' bits.
+        return ((uint32_t)values_.size() - 1) * 64 + last_size_;
     }
 
     void AppendValue(uint128_t value, uint8_t length) {
+        if (length > 64) {
+            std::cout << "SPLITTING AppendValue" << std::endl;
+            DoAppendValue(value>>64,length-64);
+            DoAppendValue((uint64_t)value,64);
+        }
+        else{
+            DoAppendValue((uint64_t)value,length);
+        }
+    }
+       
+    void DoAppendValue(uint64_t value, uint8_t length) {
         // The last bucket is full or no bucket yet, create a new one.
-        if (values_.size() == 0 || last_size_ == 128) {
+        if (values_.size() == 0 || last_size_ == 64) {
             values_.push_back(value);
             last_size_ = length;
         } else {
-            uint8_t free_bits = 128 - last_size_;
+            uint8_t free_bits = 64 - last_size_;
             // If the value fits into the last bucket, append it all there.
             if (length <= free_bits) {
                 values_[values_.size() - 1] = (values_[values_.size() - 1] << length) + value;
                 last_size_ += length;
             } else {
                 // Otherwise, append the prefix into the last bucket, and create a new bucket for the suffix.
-                uint128_t prefix, suffix;
+                uint64_t prefix, suffix;
                 SplitNumberByPrefix(value, length, free_bits, &prefix, &suffix);
                 values_[values_.size() - 1] = (values_[values_.size() - 1] << free_bits) + prefix;
                 values_.push_back(suffix);
@@ -503,8 +519,8 @@ template <class T> class BitsGeneric {
     friend BitsGeneric<X> operator>>(BitsGeneric<X> lhs, uint32_t shift_amount);
 
  private:
-    static void SplitNumberByPrefix(uint128_t number, uint8_t num_bits, uint8_t prefix_size, uint128_t* prefix,
-                             uint128_t* suffix) {
+    static void SplitNumberByPrefix(uint64_t number, uint8_t num_bits, uint8_t prefix_size, uint64_t* prefix,
+                             uint64_t* suffix) {
         assert(num_bits >= prefix_size);
         if (prefix_size == 0) {
             *prefix = 0;
@@ -512,7 +528,7 @@ template <class T> class BitsGeneric {
             return;
         }
         uint8_t suffix_size = num_bits - prefix_size;
-        uint128_t mask = (static_cast<uint128_t>(1)) << suffix_size;
+        uint64_t mask = (static_cast<uint64_t>(1)) << suffix_size;
         mask--;
         *suffix = number & mask;
         *prefix = number >> suffix_size;
@@ -574,21 +590,21 @@ BitsGeneric<T> operator<<(BitsGeneric<T> lhs, uint32_t shift_amount) {
     }
     BitsGeneric<T> result;
     // Shifts are cyclic, shifting by the number of bits gives the same number.
-    int num_blocks_shift = static_cast<int>(shift_amount / 128);
-    uint32_t shift_remainder = shift_amount % 128;
+    int num_blocks_shift = static_cast<int>(shift_amount / 64);
+    uint32_t shift_remainder = shift_amount % 64;
     for (uint32_t i = 0; i < lhs.values_.size(); i++) {
-        uint128_t new_value = 0;
+        uint64_t new_value = 0;
         if (i + num_blocks_shift < lhs.values_.size()) {
             new_value += (lhs.values_[i + num_blocks_shift] << shift_remainder);
         }
         if (i + num_blocks_shift + 1 < lhs.values_.size()) {
-            new_value += (lhs.values_[i + num_blocks_shift + 1] >> (128 - shift_remainder));
+            new_value += (lhs.values_[i + num_blocks_shift + 1] >> (64 - shift_remainder));
         }
         uint8_t new_length;
         if (i == (uint32_t)lhs.values_.size() - 1) {
             new_length = lhs.last_size_;
         } else {
-            new_length = 128;
+            new_length = 64;
         }
         result.AppendValue(new_value, new_length);
     }
@@ -602,22 +618,22 @@ BitsGeneric<T> operator>>(BitsGeneric<T> lhs, uint32_t shift_amount) {
     }
     BitsGeneric<T> result;
 
-    int num_blocks_shift = static_cast<int>(shift_amount / 128);
-    uint32_t shift_remainder = shift_amount % 128;
+    int num_blocks_shift = static_cast<int>(shift_amount / 64);
+    uint32_t shift_remainder = shift_amount % 64;
 
     for (int i = 0; i < lhs.values_.size(); i++) {
-        uint128_t new_value = 0;
+        uint64_t new_value = 0;
         if (i - num_blocks_shift >= 0) {
             new_value += (lhs.values_[i - num_blocks_shift] >> shift_remainder);
         }
         if (i - num_blocks_shift - 1 >= 0) {
-            new_value += (lhs.values_[i - num_blocks_shift - 1] << (128 - shift_remainder));
+            new_value += (lhs.values_[i - num_blocks_shift - 1] << (64 - shift_remainder));
         }
         uint8_t new_length;
         if (i == lhs.values_.size() - 1) {
             new_length = lhs.last_size_;
         } else {
-            new_length = 128;
+            new_length = 64;
         }
         result.AppendValue(new_value, new_length);
     }
@@ -625,7 +641,7 @@ BitsGeneric<T> operator>>(BitsGeneric<T> lhs, uint32_t shift_amount) {
 }
 
 
-typedef std::vector<uint128_t> LargeVector;
+typedef std::vector<uint64_t> LargeVector;
 using Bits = BitsGeneric<SmallVector>;
 using ParkBits = BitsGeneric<ParkVector>;
 using LargeBits = BitsGeneric<LargeVector>;

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -19,11 +19,11 @@ class TestPythonBindings(unittest.TestCase):
         pr = DiskProver(str(Path("myplot.dat")))
 
         total_proofs: int = 0
-        iterations: int = 100
+        iterations: int = 5000
 
         v = Verifier()
         for i in range(iterations):
-            if i % 10 == 0:
+            if i % 100 == 0:
                 print(i)
             challenge = sha256(i.to_bytes(4, "big")).digest()
             for index, quality in enumerate(pr.get_qualities_for_challenge(challenge)):
@@ -35,7 +35,7 @@ class TestPythonBindings(unittest.TestCase):
 
         print(f"total proofs {total_proofs} out of {iterations}\
             {total_proofs / iterations}")
-        # assert total_proofs == 90
+        assert total_proofs == 4647
         pr = None
         Path("myplot.dat").unlink()
 


### PR DESCRIPTION
Use uint64_t as type for bit manipulation instead of uint128_t. Should speed up visual studio while not affecting gcc builds.