### PR TITLE
Revert floor removal in DiskProver

### DIFF
--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <utility>
 #include <algorithm>    // std::min
+#include <math.h>
 
 #include "util.hpp"
 #include "encoding.hpp"
@@ -93,9 +94,9 @@ class DiskProver {
         // read from disk the C1 and C3 entries.
         uint8_t c2_size = (Util::ByteAlign(k) / 8);
         uint8_t* c2_buf = new uint8_t[c2_size];
-        for (uint32_t i = 0; i < (table_begin_pointers[10] -
-                                  table_begin_pointers[9]) /
-                                  c2_size - 1; i++) {
+        for (uint32_t i = 0; i < floor((table_begin_pointers[10] -
+                                table_begin_pointers[9]) /
+                                  c2_size) - 1; i++) {
             disk_file.read(reinterpret_cast<char*>(c2_buf), c2_size);
             this->C2.push_back(Bits(c2_buf, c2_size, c2_size*8).Slice(0, k).GetValue());
         }


### PR DESCRIPTION
This was causing a memory leak for plots of size k=31 (infinite running loop). The exact reason why it's going below zero is not clear, since there should always be a buffer entry in the C2 list.