### PR TITLE
remove cmake requirement from project.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.5.0", "cmake>=3.1.0", "pybind11"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.5.0", "pybind11"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
The cmake requirement in project.toml makes pip attempt to install cmake (and fail) on Pi4 Ubuntu 20.04LTS. CMake requirements instead handled by the wrapping installer.