### PR TITLE
Copymovewjb

### DIFF
--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -99,6 +99,7 @@ class DiskPlotter {
         // Cross platform way to concatenate paths, gulrak library.
         fs::path tmp_1_filename = fs::path(tmp_dirname) / fs::path(filename + ".tmp");
         fs::path tmp_2_filename = fs::path(tmp2_dirname) / fs::path(filename + ".2.tmp");
+        fs::path final_2_filename = fs::path(final_dirname) / fs::path(filename + ".2.tmp");
         fs::path final_filename = fs::path(final_dirname) / fs::path(filename);
 
         // Check if the paths exist
@@ -186,7 +187,8 @@ class DiskPlotter {
             std::cout << "Moved final file to " << final_filename << std::endl;
         }
         else {
-            fs::copy(tmp_2_filename, final_filename, fs::copy_options::overwrite_existing);
+            fs::copy(tmp_2_filename, final_2_filename, fs::copy_options::overwrite_existing);
+            fs::rename(final_2_filename, final_filename);
             bool removed_2 = fs::remove(tmp_2_filename);
             std::cout << "Copied final file to " << final_filename << std::endl;
             std::cout << "Removed " << tmp_2_filename << "? " << removed_2 << std::endl;

--- a/src/sort_on_disk.hpp
+++ b/src/sort_on_disk.hpp
@@ -31,8 +31,6 @@ class SortOnDiskUtils {
      * index, to the given index.
      */
     inline static uint64_t ExtractNum(uint8_t* bytes, uint32_t len_bytes, uint32_t begin_bits, uint32_t take_bits) {
-        uint32_t start_index = begin_bits / 8;
-        uint32_t end_index;
         if ((begin_bits + take_bits) / 8 > len_bytes - 1) {
             take_bits = len_bytes * 8 - begin_bits;
         }


### PR DESCRIPTION
Atomic rename after copy to tmp filename. This is to avoid invalid plots when halfway copied.