### PR TITLE
Report correct working space based on sort spare space used

### DIFF
--- a/src/pos_constants.hpp
+++ b/src/pos_constants.hpp
@@ -26,6 +26,9 @@ const uint32_t kMinPlotSize = 15;
 // Set to 50 since k + kExtraBits + k*4 must not exceed 256 (BLAKE3 output size)
 const uint32_t kMaxPlotSize = 50;
 
+// The amount of spare space used for sort on disk (multiplied time memory buffer size)
+const uint32_t kSpareMultiplier = 5;
+
 // How many f7s per C1 entry, and how many C1 entries per C2 entry
 const uint32_t kCheckpoint1Interval = 10000;
 const uint32_t kCheckpoint2Interval = 10000;


### PR DESCRIPTION
Sort on disk also uses working space (up to maximum of 5 * memoryBufferSize). We need to add this to the final number to report the correct number. 

Have tested on k=25s.