### PR TITLE
Ms.metadata

### DIFF
--- a/src/encoding.hpp
+++ b/src/encoding.hpp
@@ -137,6 +137,17 @@ class Encoding {
                                         deltas.size(), CT_MEMO[R]);
     }
 
+    static void ANSFree(double R) {
+        if (CT_MEMO.find(R) != CT_MEMO.end()) {
+            FSE_freeCTable(CT_MEMO[R]);
+            CT_MEMO.erase(R);
+        }
+        if (DT_MEMO.find(R) != DT_MEMO.end()) {
+            FSE_freeDTable(DT_MEMO[R]);
+            DT_MEMO.erase(R);
+        }
+    }
+
     static std::vector<uint8_t> ANSDecodeDeltas(const uint8_t *inp, size_t inp_size, int numDeltas, double R) {
         if (DT_MEMO.find(R) == DT_MEMO.end()) {
             std::vector<short> nCount = Encoding::CreateNormalizedCount(R);

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -515,7 +515,7 @@ class DiskPlotter {
             uint64_t matches = 0;  // Total matches
 
             // Buffers for storing a left or a right entry, used for disk IO
-            uint8_t left_buf[entry_size_bytes];
+            uint8_t *left_buf = new uint8_t[entry_size_bytes];
             uint8_t* right_buf;
             uint8_t* tmp_buf;
 
@@ -788,6 +788,8 @@ class DiskPlotter {
 
             computation_pass_timer.PrintElapsed("\tComputation pass time:");
             table_timer.PrintElapsed("Forward propagation table time:");
+
+            delete[] left_buf;
         }
         table_sizes[0] = max_spare_written;
         return table_sizes;

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -713,11 +713,11 @@ class DiskPlotter {
                             newrpos = R_position_map.at(R_entry.pos % (1 << 10)) + R_position_base;
                             // Position in the previous table
                             new_entry.AppendValue(newlpos, pos_size);
-
+                            std::cout << "Old positions:" << L_entry.pos << " " << R_entry.pos << std::endl;
+                            std::cout << "New positions:" << newlpos << " " << newrpos << std::endl;
                             // Offset for matching entry
                             if (newrpos - newlpos > (1U << kOffsetSize) * 97 / 100) {
-                                std::cout << "Old positions:" << L_entry.pos << " " << R_entry.pos << std::endl;
-                                std::cout << "New positions:" << newlpos << " " << newrpos << std::endl;
+
                                 std::cout << "Offset: " <<  newrpos - newlpos << std::endl;
                                 abort();
                             }

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -645,6 +645,7 @@ class DiskPlotter {
                             // The new position for this entry = the total amount of thing written to L so far. Since we only
                             // write entries in not_dropped, about 14% of entries are dropped.
                             R_position_map[entry->pos % (1<<10)] = left_writer_count - R_position_base;
+                            std::cout << "Mapping " << entry->pos << " to " << left_writer_count << std::endl;
                             left_writer_count++;
                             new_left_entry.ToBytes(tmp_buf);
                             if(left_writer_count % left_buf_entries==0) {

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -121,8 +121,7 @@ class DiskPlotter {
             return;
         }
         for (fs::path& p : tmp_1_filenames) {
-            bool r = fs::remove(p);
-            std::cout << "remove? " << p << " ? " << r << std::endl;
+            fs::remove(p);
         }
         fs::remove(tmp_2_filename);
         fs::remove(final_filename);
@@ -140,6 +139,8 @@ class DiskPlotter {
             FileDisk d4(tmp_1_filenames[4]);
             FileDisk d5(tmp_1_filenames[5]);
             FileDisk d6(tmp_1_filenames[6]);
+            FileDisk d7(tmp_1_filenames[7]);
+            tmp_1_disks.push_back(&d0);
             tmp_1_disks.push_back(&d1);
             tmp_1_disks.push_back(&d2);
             tmp_1_disks.push_back(&d3);
@@ -542,7 +543,6 @@ class DiskPlotter {
                     // Rewrite left entry with just pos and offset, to reduce working space
                     Bits new_left_entry = Bits(pos_read, pos_size);
                     new_left_entry += Bits(offset_read, kOffsetSize);
-                    // std::cout << "Read " << left_entry.y << " " << pos_read << " " << offset_read << std::endl;
                     new_left_entry.ToBytes(left_buf);
                     uint16_t to_write =  Util::ByteAlign(new_left_entry.GetSize()) / 8;
                     (*tmp_1_disks[table_index]).Write(left_writer, left_buf, compressed_entry_size_bytes);
@@ -889,7 +889,6 @@ class DiskPlotter {
                     if(left_reader_count%left_buf_entries==0) {
                          uint64_t readAmt=std::min(left_buf_entries*left_entry_size_bytes,
                             (table_sizes[table_index - 1] - left_reader_count) * left_entry_size_bytes);
-                        std::cout << "Starting to read " << (table_index - 1) << " num " << readAmt << "ts:" << table_sizes[table_index - 1] << std::endl;
                          (*tmp_1_disks[table_index - 1]).Read(left_reader, left_reader_buf,
                                 readAmt);
                          left_reader+=readAmt;
@@ -907,11 +906,6 @@ class DiskPlotter {
                                                                   0, pos_size);
                             entry_offset = Util::SliceInt64FromBytes(left_entry_buf, left_entry_size_bytes,
                                                                      pos_size, kOffsetSize);
-                            if (current_pos < 5) {
-                                std::cout << (int)table_index << " pos " << (int)current_pos << " " << Bits(left_entry_buf, 7, 7*8) << std::endl;
-                                std::cout << (int)table_index << " pos/ offset " << (int)entry_pos << " " << (int)entry_offset << std::endl;
-                                // std::cout << (int)table_index << " Left entry size bytes: " << (int)left_entry_size_bytes << std::endl;
-                            }
                         } else {
                             entry_y = Util::SliceInt64FromBytes(left_entry_buf, left_entry_size_bytes,
                                                                          0, k + kExtraBits);
@@ -931,9 +925,6 @@ class DiskPlotter {
                             new_left_entry += Bits(entry_pos, pos_size);
                             new_left_entry += Bits(entry_offset, kOffsetSize);
                             new_left_entry += Bits(left_entry_counter, k + 1);
-                            // if (current_pos < 20) {
-                            //     std::cout << (int)table_index << " Writing p/o: " << (int)entry_pos << " " << (int)entry_offset << std::endl;
-                            // }
 
                             // If we are not taking up all the bits, make sure they are zeroed
                             if (Util::ByteAlign(new_left_entry.GetSize()) < left_entry_size_bytes * 8) {
@@ -943,7 +934,6 @@ class DiskPlotter {
                             // For table one entries, we don't care about sort key, only y and x.
                             new_left_entry += Bits(entry_y, k + kExtraBits);
                             new_left_entry += Bits(entry_metadata, left_metadata_size);
-                            // std::cout << "Writing X:" << entry_metadata.GetValue() << std::endl;
                         }
                         new_left_entry.ToBytes(new_left_entry_buf);
 

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -644,7 +644,7 @@ class DiskPlotter {
                             tmp_buf=left_writer_buf + (left_writer_count % left_buf_entries) * compressed_entry_size_bytes;
                             // The new position for this entry = the total amount of thing written to L so far. Since we only
                             // write entries in not_dropped, about 14% of entries are dropped.
-                            R_position_map[entry->pos % (1<<12)] = left_writer_count - R_position_base;
+                            R_position_map[entry->pos % (1<<10)] = left_writer_count - R_position_base;
                             left_writer_count++;
                             new_left_entry.ToBytes(tmp_buf);
                             if(left_writer_count % left_buf_entries==0) {
@@ -685,6 +685,7 @@ class DiskPlotter {
                                 future_entries_to_write.emplace_back(std::make_tuple(std::move(L_entry), std::move(R_entry), std::move(f_output)));
                             }
                         }
+                        std::cout << "Matches: " << future_entries_to_write.size() << std::endl;
                         // At this point, future_entries_to_write contains the matches of buckets L and R, and current_entries_to_write
                         // contains the matches of L and the bucket left of L. These are the ones that we will write.
                         uint16_t final_current_entry_size = current_entries_to_write.size();
@@ -704,11 +705,11 @@ class DiskPlotter {
                             // Maps the new positions. If we hit end of pos, we must write things in both final_entries to write
                             // and current_entries_to_write, which are in both position maps.
                             if (!end_of_table || i < final_current_entry_size) {
-                                newlpos = L_position_map.at(L_entry.pos % (1 << 12)) + L_position_base;
+                                newlpos = L_position_map.at(L_entry.pos % (1 << 10)) + L_position_base;
                             } else {
-                                newlpos = R_position_map.at(L_entry.pos % (1 << 12)) + R_position_base;
+                                newlpos = R_position_map.at(L_entry.pos % (1 << 10)) + R_position_base;
                             }
-                            newrpos = R_position_map.at(R_entry.pos % (1 << 12)) + R_position_base;
+                            newrpos = R_position_map.at(R_entry.pos % (1 << 10)) + R_position_base;
                             // Position in the previous table
                             new_entry.AppendValue(newlpos, pos_size);
 

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -463,6 +463,7 @@ class DiskPlotter {
 
         // For tables 1 through 6, sort the table, calculate matches, and write
         // the next table. This is the left table index.
+
         for (uint8_t table_index = 1; table_index < 7; table_index++) {
             Timer table_timer;
             uint8_t metadata_size = kVectorLens[table_index + 1] * k;
@@ -536,6 +537,9 @@ class DiskPlotter {
             // Start at left table pos = 0 and iterate through the whole table. Note that the left table
             // will already be sorted by y
             while (!end_of_table) {
+                if (pos > 100 && table_index == 2) {
+                    exit(0);
+                }
                 PlotEntry left_entry;
                 left_entry.right_metadata = 0;
                 // Reads a left entry from disk
@@ -568,6 +572,9 @@ class DiskPlotter {
                                                                                  + kOffsetSize + 128,
                                                                                metadata_size - 128);
                     }
+                }
+                if (table_index == 2) {
+                    std::cout << "Read " << Bits(left_entry.read_posoffset, pos_size).GetValue() << " " << Bits(left_entry.read_posoffset, pos_size + kOffsetSize).Slice(pos_size).GetValue() << " " << (int)left_entry.y << std::endl;
                 }
 
                 // This is not the pos that was read from disk,but the position of the entry we read, within L table.

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -614,7 +614,6 @@ class DiskPlotter {
                             if (table_index == 1) {
                                 new_left_entry = Bits(entry->left_metadata, k);
                             } else {
-                                assert(Bits(entry->read_posoffset, pos_size + kOffsetSize).s)
                                 assert(entry->read_posoffset & 1 == 0);
                                 new_left_entry = Bits(entry->read_posoffset, pos_size + kOffsetSize).Slice(1);
                             }
@@ -808,10 +807,9 @@ class DiskPlotter {
             if (table_index != 7) {
                 std::cout << "\tSorting table " << int{table_index} << std::endl;
                 Timer sort_timer;
-                int do_quicksort = table_index == 6;
                 Sorting::SortOnDisk((*tmp_1_disks[table_index]), 0, *tmp_1_disks[0],
                                     right_entry_size_bytes,
-                                    0, bucket_sizes_pos, memory, memorySize, do_quicksort);
+                                    0, bucket_sizes_pos, memory, memorySize);
 
                 sort_timer.PrintElapsed("\tSort time:");
             }

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -681,7 +681,7 @@ class DiskPlotter {
                                                              Bits(R_entry.y, k + kExtraBits),
                                                              Bits(L_entry.left_metadata, metadata_size),
                                                              Bits(R_entry.left_metadata, metadata_size));
-                                future_entries_to_write.emplace_back(std::make_tuple(std::move(L_entry), std::move(R_entry), std::move(f_output)));
+                                future_entries_to_write.push_back(std::make_tuple(L_entry, R_entry, f_output));
                             } else {
                                 // Metadata does not fit into 128 bits
                                 const std::pair<Bits, Bits>& f_output = f.CalculateBucket(Bits(L_entry.y, k + kExtraBits),
@@ -690,7 +690,7 @@ class DiskPlotter {
                                                               + Bits(L_entry.right_metadata, metadata_size - 128),
                                                              Bits(R_entry.left_metadata, 128)
                                                               + Bits(R_entry.right_metadata, metadata_size - 128));
-                                future_entries_to_write.emplace_back(std::make_tuple(std::move(L_entry), std::move(R_entry), std::move(f_output)));
+                                future_entries_to_write.push_back(std::make_tuple(L_entry, R_entry, f_output));
                             }
                         }
                         std::cout << "Matches: " << future_entries_to_write.size() << std::endl;
@@ -706,7 +706,7 @@ class DiskPlotter {
                             const PlotEntry& L_entry = std::get<0>(entry_tuple);
                             const PlotEntry& R_entry = std::get<1>(entry_tuple);
 
-                            const std::pair<Bits, Bits> f_output = std::get<2>(entry_tuple);
+                            const std::pair<Bits, Bits>& f_output = std::get<2>(entry_tuple);
                             // We only need k instead of k + kExtraBits bits for the last table
                             Bits new_entry = table_index + 1 == 7 ? std::get<0>(f_output).Slice(0, k) : std::get<0>(f_output);
 

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -191,7 +191,7 @@ class DiskPlotter {
             WriteCTables(k, k + 1, tmp2_disk, tmp_1_disks, res);
             p4.PrintElapsed("Time for phase 4 =");
 
-            uint64_t total_working_space = 0;
+            uint64_t total_working_space = table_sizes[0];
             for (size_t i=1; i <=7; i++) {
                 total_working_space += table_sizes[i] * GetMaxEntrySize(k, i, false);
             }
@@ -763,11 +763,7 @@ class DiskPlotter {
             computation_pass_timer.PrintElapsed("\tComputation pass time:");
             table_timer.PrintElapsed("Forward propagation table time:");
         }
-        for (int i=0; i<=7; i++) {
-            std::cout << "Table " << i << " " << table_sizes[i] << std::endl;
-        }
-        // abort();
-        // exit(0);
+        table_sizes[0] = max_spare_written;
         return table_sizes;
     }
 

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -166,7 +166,7 @@ class DiskPlotter {
             assert(id_len == kIdLen);
 
             // Memory to be used for sorting and buffers
-            uint8_t* memory = new uint8_t[memorySize];
+            uint8_t* memory = new uint8_t[memorySize]();
 
             std::cout << std::endl << "Starting phase 1/4: Forward Propagation into table tmp files... " << Timer::GetNow();
 
@@ -1517,7 +1517,6 @@ class DiskPlotter {
                 }
                 last_line_point = line_point;
             }
-            Encoding::ANSFree(kRValues[table_index - 1]);
 
             (*tmp_1_disks[table_index + 1]).Write(right_writer, right_writer_buf,
                 (right_writer_count%right_buf_entries)*right_entry_size_bytes);
@@ -1537,6 +1536,7 @@ class DiskPlotter {
                 final_entries_written += (park_stubs.size() + 1);
             }
 
+            Encoding::ANSFree(kRValues[table_index - 1]);
             std::cout << "\tWrote " << final_entries_written << " entries" << std::endl;
 
             final_table_begin_pointers[table_index + 1] = final_table_begin_pointers[table_index]

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -577,7 +577,7 @@ class DiskPlotter {
                     // so now we can compare entries in both buckets to find matches. If two entries match,
                     // the result is written to the right table.
                     if (bucket_L.size() > 0) {
-                        not_dropped = std::vector<PlotEntry*>();
+                        not_dropped.clear();
 
                         if (bucket_R.size() > 0) {
                             // Compute all matches between the two buckets, and return indeces into each bucket
@@ -618,7 +618,7 @@ class DiskPlotter {
                                 new_left_entry = Bits(entry->read_posoffset, pos_size + kOffsetSize).Slice(1);
                             }
                             tmp_buf=left_writer_buf + (left_writer_count % left_buf_entries) * compressed_entry_size_bytes;
-                            R_position_map[entry->pos % (1<<16)] = left_writer_count - R_position_base;
+                            R_position_map[entry->pos % (1<<10)] = left_writer_count - R_position_base;
                             left_writer_count++;
                             new_left_entry.ToBytes(tmp_buf);
                             if(left_writer_count % left_buf_entries==0) {
@@ -673,11 +673,11 @@ class DiskPlotter {
                             // We only need k instead of k + kExtraBits bits for the last table
                             Bits new_entry = table_index + 1 == 7 ? std::get<0>(f_output).Slice(0, k) : std::get<0>(f_output);
                             if (!end_of_table || i < final_current_entry_size) {
-                                newlpos = L_position_map[L_entry.pos % (1 << 16)] + L_position_base;
+                                newlpos = L_position_map.at(L_entry.pos % (1 << 10)) + L_position_base;
                             } else {
-                                newlpos = R_position_map[L_entry.pos % (1 << 16)] + R_position_base;
+                                newlpos = R_position_map.at(L_entry.pos % (1 << 10)) + R_position_base;
                             }
-                            newrpos = R_position_map[R_entry.pos % (1 << 16)] + R_position_base;
+                            newrpos = R_position_map.at(R_entry.pos % (1 << 10)) + R_position_base;
                             // Position in the previous table
                             if (table_index + 1 == 7) {
                                 assert(newlpos < (1 << new_pos_size));

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -523,7 +523,7 @@ class DiskPlotter {
             std::vector<std::tuple<PlotEntry, PlotEntry, std::pair<Bits, Bits>> > current_entries_to_write;
             std::vector<std::tuple<PlotEntry, PlotEntry, std::pair<Bits, Bits>> > future_entries_to_write;
             std::vector<std::pair<uint16_t, uint16_t> > match_indexes;
-            std::vector<PlotEntry*> not_dropped;  // Pointers are stored to avoid copying entries
+            std::vector<PlotEntry> not_dropped;  // Pointers are stored to avoid copying entries
 
             // Stores map of old positions to new positions (positions after dropping entries from L table that did not match)
             // Map ke
@@ -609,7 +609,7 @@ class DiskPlotter {
                         for (size_t bucket_index = 0; bucket_index < bucket_L.size(); bucket_index++) {
                             PlotEntry& L_entry = bucket_L[bucket_index];
                             if (L_entry.used) {
-                                not_dropped.emplace_back(&bucket_L[bucket_index]);
+                                not_dropped.emplace_back(bucket_L[bucket_index]);
                             }
                         }
                         if (end_of_table) {
@@ -619,7 +619,7 @@ class DiskPlotter {
                             for (size_t bucket_index = 0; bucket_index < bucket_R.size(); bucket_index++) {
                                 PlotEntry& R_entry = bucket_R[bucket_index];
                                 if (R_entry.used) {
-                                    not_dropped.emplace_back(&R_entry);
+                                    not_dropped.emplace_back(R_entry);
                                 }
                             }
                         }
@@ -630,20 +630,20 @@ class DiskPlotter {
                         L_position_map.swap(R_position_map);
                         R_position_base = left_writer_count;
 
-                        for (PlotEntry* &entry : not_dropped) {
+                        for (PlotEntry &entry : not_dropped) {
                             // Rewrite left entry with just pos and offset, to reduce working space
                             if (table_index == 1) {
                                 // Table 1 goes from (f1, x) to just (x)
-                                new_left_entry = Bits(entry->left_metadata, k);
+                                new_left_entry = Bits(entry.left_metadata, k);
                             } else {
-                                assert(entry->read_posoffset & 1 == 0);
+                                assert(entry.read_posoffset & 1 == 0);
                                 // Other tables goes from (f1, pos, offset, metadata) to just (pos, offset)
-                                new_left_entry = Bits(entry->read_posoffset, pos_size + kOffsetSize);
+                                new_left_entry = Bits(entry.read_posoffset, pos_size + kOffsetSize);
                             }
                             tmp_buf=left_writer_buf + (left_writer_count % left_buf_entries) * compressed_entry_size_bytes;
                             // The new position for this entry = the total amount of thing written to L so far. Since we only
                             // write entries in not_dropped, about 14% of entries are dropped.
-                            R_position_map[entry->pos % (1<<10)] = left_writer_count - R_position_base;
+                            R_position_map[entry.pos % (1<<10)] = left_writer_count - R_position_base;
                             left_writer_count++;
                             new_left_entry.ToBytes(tmp_buf);
                             if(left_writer_count % left_buf_entries==0) {

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -706,7 +706,7 @@ class DiskPlotter {
                             const PlotEntry& L_entry = std::get<0>(entry_tuple);
                             const PlotEntry& R_entry = std::get<1>(entry_tuple);
 
-                            const std::pair<Bits, Bits>& f_output = std::get<2>(entry_tuple);
+                            const std::pair<Bits, Bits> f_output = std::get<2>(entry_tuple);
                             // We only need k instead of k + kExtraBits bits for the last table
                             Bits new_entry = table_index + 1 == 7 ? std::get<0>(f_output).Slice(0, k) : std::get<0>(f_output);
 
@@ -731,6 +731,7 @@ class DiskPlotter {
                             new_entry.AppendValue(newrpos - newlpos, kOffsetSize);
                             // New metadata which will be used to compute the next f
                             new_entry += std::get<1>(f_output);
+                            std::cout << "Wrotey " << std::get<0>(f_output).GetValue() << " " << newrpos << " " << (newrpos - newlpos) << " " << std::endl;
 
                             right_buf=right_writer_buf+(right_writer_count%right_buf_entries)*right_entry_size_bytes;
                             right_writer_count++;

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -672,7 +672,7 @@ class DiskPlotter {
                                                              Bits(R_entry.y, k + kExtraBits),
                                                              Bits(L_entry.left_metadata, metadata_size),
                                                              Bits(R_entry.left_metadata, metadata_size));
-                                future_entries_to_write.emplace_back(std::make_tuple(std::move(L_entry), std::move(R_entry), std::move(f_output)));
+                                future_entries_to_write.push_back(std::make_tuple(L_entry, R_entry, f_output));
                             } else {
                                 // Metadata does not fit into 128 bits
                                 const std::pair<Bits, Bits>& f_output = f.CalculateBucket(Bits(L_entry.y, k + kExtraBits),
@@ -681,7 +681,7 @@ class DiskPlotter {
                                                               + Bits(L_entry.right_metadata, metadata_size - 128),
                                                              Bits(R_entry.left_metadata, 128)
                                                               + Bits(R_entry.right_metadata, metadata_size - 128));
-                                future_entries_to_write.emplace_back(std::make_tuple(std::move(L_entry), std::move(R_entry), std::move(f_output)));
+                                future_entries_to_write.push_back(std::make_tuple(L_entry, R_entry, f_output));
                             }
                         }
                         // At this point, future_entries_to_write contains the matches of buckets L and R, and current_entries_to_write

--- a/src/pos_constants.hpp
+++ b/src/pos_constants.hpp
@@ -21,7 +21,7 @@
 const uint32_t kIdLen = 32;
 
 // Must be set high enough to prevent attacks of fast plotting
-const uint32_t kMinPlotSize = 13;
+const uint32_t kMinPlotSize = 15;
 
 // Set to 50 since k + kExtraBits + k*4 must not exceed 256 (BLAKE3 output size)
 const uint32_t kMaxPlotSize = 50;

--- a/src/pos_constants.hpp
+++ b/src/pos_constants.hpp
@@ -21,7 +21,7 @@
 const uint32_t kIdLen = 32;
 
 // Must be set high enough to prevent attacks of fast plotting
-const uint32_t kMinPlotSize = 15;
+const uint32_t kMinPlotSize = 14;
 
 // Set to 50 since k + kExtraBits + k*4 must not exceed 256 (BLAKE3 output size)
 const uint32_t kMaxPlotSize = 50;

--- a/src/pos_constants.hpp
+++ b/src/pos_constants.hpp
@@ -21,7 +21,7 @@
 const uint32_t kIdLen = 32;
 
 // Must be set high enough to prevent attacks of fast plotting
-const uint32_t kMinPlotSize = 15;
+const uint32_t kMinPlotSize = 13;
 
 // Set to 50 since k + kExtraBits + k*4 must not exceed 256 (BLAKE3 output size)
 const uint32_t kMaxPlotSize = 50;
@@ -69,6 +69,8 @@ struct PlotEntry {
     uint64_t offset;
     uint128_t left_metadata;  // We only use left_metadata, unless metadata does not
     uint128_t right_metadata; // fit in 128 bits.
+    bool used; // Whether the entry was used in the next table of matches
+    uint64_t read_posoffset; // The combined pos and offset that this entry points to
 };
 
 #endif  // SRC_CPP_POS_CONSTANTS_HPP_

--- a/src/pos_constants.hpp
+++ b/src/pos_constants.hpp
@@ -21,7 +21,7 @@
 const uint32_t kIdLen = 32;
 
 // Must be set high enough to prevent attacks of fast plotting
-const uint32_t kMinPlotSize = 14;
+const uint32_t kMinPlotSize = 15;
 
 // Set to 50 since k + kExtraBits + k*4 must not exceed 256 (BLAKE3 output size)
 const uint32_t kMaxPlotSize = 50;

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -120,6 +120,10 @@ class DiskProver {
     ~DiskProver() {
         std::lock_guard<std::mutex> l(_mtx);
         delete[] this->memo;
+        for (int i=0; i<6; i++) {
+            Encoding::ANSFree(kRValues[i]);
+        }
+        Encoding::ANSFree(kC3R);
     }
 
     void GetMemo(uint8_t* buffer) {
@@ -317,7 +321,6 @@ class DiskProver {
         delete[] line_point_bin;
         delete[] stubs_bin;
         delete[] deltas_bin;
-        Encoding::ANSFree(kRValues[table_index - 1]);
 
         return final_line_point;
     }
@@ -329,7 +332,6 @@ class DiskProver {
         std::vector<uint8_t> deltas = Encoding::ANSDecodeDeltas(bit_mask, encoded_size,
                                                                 kCheckpoint1Interval, kC3R);
         std::vector<uint64_t> p7_positions;
-        Encoding::ANSFree(kC3R);
         for (uint8_t delta : deltas) {
             if (curr_f7 > f7) {
                 break;

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -317,6 +317,7 @@ class DiskProver {
         delete[] line_point_bin;
         delete[] stubs_bin;
         delete[] deltas_bin;
+        Encoding::ANSFree(kRValues[table_index - 1]);
 
         return final_line_point;
     }
@@ -328,6 +329,7 @@ class DiskProver {
         std::vector<uint8_t> deltas = Encoding::ANSDecodeDeltas(bit_mask, encoded_size,
                                                                 kCheckpoint1Interval, kC3R);
         std::vector<uint64_t> p7_positions;
+        Encoding::ANSFree(kC3R);
         for (uint8_t delta : deltas) {
             if (curr_f7 > f7) {
                 break;

--- a/src/sort_on_disk.hpp
+++ b/src/sort_on_disk.hpp
@@ -158,7 +158,7 @@ class FileDisk : public Disk {
     }
 
     inline std::string GetFileName() const noexcept {
-        return filename_;
+        return filename_.string();
     }
 
     inline uint64_t GetWriteMax() const noexcept {
@@ -171,6 +171,9 @@ class FileDisk : public Disk {
 
 
  private:
+    FileDisk(const FileDisk&);
+    FileDisk& operator=(const FileDisk&);
+
     uint64_t readPos=0;
     uint64_t writePos=0;
     uint64_t writeMax=0;

--- a/src/sort_on_disk.hpp
+++ b/src/sort_on_disk.hpp
@@ -84,6 +84,7 @@ class Disk {
     virtual void Read(uint64_t begin, uint8_t* memcache, uint64_t length) = 0;
     virtual void Write(uint64_t begin, const uint8_t* memcache, uint64_t length) = 0;
     virtual void Truncate(uint64_t new_size) = 0;
+    virtual ~Disk() {};
 };
 
 class FileDisk : public Disk {

--- a/src/sort_on_disk.hpp
+++ b/src/sort_on_disk.hpp
@@ -83,7 +83,7 @@ class Disk {
  public:
     virtual void Read(uint64_t begin, uint8_t* memcache, uint64_t length) = 0;
     virtual void Write(uint64_t begin, const uint8_t* memcache, uint64_t length) = 0;
-    virtual void Truncate(uint64_t new_size);
+    virtual void Truncate(uint64_t new_size) = 0;
 };
 
 class FileDisk : public Disk {
@@ -164,7 +164,7 @@ class FileDisk : public Disk {
         return writeMax;
     }
 
-    inline void Truncate(uint64_t new_size) {
+    inline void Truncate(uint64_t new_size) override {
         fs::resize_file(filename_, new_size);
     }
 

--- a/src/sort_on_disk.hpp
+++ b/src/sort_on_disk.hpp
@@ -166,7 +166,10 @@ class FileDisk : public Disk {
     }
 
     inline void Truncate(uint64_t new_size) override {
-//        fs::resize_file(filename_, new_size);
+        if(f_!=NULL)
+            fclose(f_);
+        fs::resize_file(filename_, new_size);
+        f_=fopen(filename_.c_str(), "r+b");
     }
 
 

--- a/src/sort_on_disk.hpp
+++ b/src/sort_on_disk.hpp
@@ -166,7 +166,7 @@ class FileDisk : public Disk {
     }
 
     inline void Truncate(uint64_t new_size) override {
-        fs::resize_file(filename_, new_size);
+//        fs::resize_file(filename_, new_size);
     }
 
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -224,6 +224,13 @@ class FakeDisk : public Disk {
         f_.seekp(begin);
         f_.write(reinterpret_cast<const char*>(memcache), length);
     }
+    void Truncate(uint64_t new_size) override {
+        if (new_size <= s.size()) {
+            s = s.substr(0, new_size);
+        } else {
+            s = s + std::string(new_size - s.size(), 0);
+        }
+    }
 
  private:
     std::string s;
@@ -701,6 +708,7 @@ TEST_CASE("Sort on disk") {
         vector<Bits> input;
         uint32_t begin = 1000;
         FakeDisk disk = FakeDisk(5000000);
+        FakeDisk spare = FakeDisk(5000000);
 
         for (uint32_t i = 0; i < iters; i ++) {
             vector<unsigned char> hash_input = intToBytes(i, 4);
@@ -720,7 +728,7 @@ TEST_CASE("Sort on disk") {
 
         const uint32_t memory_len = 100000;
         uint8_t* memory = new uint8_t[memory_len];
-        Sorting::SortOnDisk(disk, begin, 3600000, size, 0, bucket_sizes, memory, memory_len);
+        Sorting::SortOnDisk(disk, begin, spare, size, 0, bucket_sizes, memory, memory_len);
 
 
         sort(input.begin(), input.end());

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -215,12 +215,16 @@ class FakeDisk : public Disk {
         f_ = std::stringstream(s, std::ios_base::in | std::ios_base::out);
     }
 
-    void Read(uint64_t begin, uint8_t* memcache, uint64_t length) {
+    ~FakeDisk() {
+
+    }
+
+    void Read(uint64_t begin, uint8_t* memcache, uint64_t length) override {
         f_.seekg(begin);
         f_.read(reinterpret_cast<char*>(memcache), length);
     }
 
-    void Write(uint64_t begin, const uint8_t* memcache, uint64_t length) {
+    void Write(uint64_t begin, const uint8_t* memcache, uint64_t length) override {
         f_.seekp(begin);
         f_.write(reinterpret_cast<const char*>(memcache), length);
     }
@@ -506,50 +510,50 @@ TEST_CASE("Plotting") {
     SECTION("Disk plot 1") {
         PlotAndTestProofOfSpace("cpp-test-plot.dat", 100, 16, plot_id_1);
     }
-    SECTION("Disk plot 2") {
-        PlotAndTestProofOfSpace("cpp-test-plot.dat", 500, 17, plot_id_3);
-    }
-    SECTION("Disk plot 3") {
-        PlotAndTestProofOfSpace("cpp-test-plot.dat", 5000, 21, plot_id_3);
-    }
+    // SECTION("Disk plot 2") {
+    //     PlotAndTestProofOfSpace("cpp-test-plot.dat", 500, 17, plot_id_3);
+    // }
+    // SECTION("Disk plot 3") {
+    //     PlotAndTestProofOfSpace("cpp-test-plot.dat", 5000, 21, plot_id_3);
+    // }
 }
 
-TEST_CASE("Invalid plot") {
-    SECTION("File gets deleted") {
-        string filename = "invalid-plot.dat";
-        {
-        DiskPlotter plotter = DiskPlotter();
-        uint8_t memo[5] = {1, 2, 3, 4, 5};
-        uint8_t k = 22;
-        plotter.CreatePlotDisk(".", ".", ".", filename, k, memo, 5, plot_id_1, 32);
-        DiskProver prover(filename);
-        uint8_t* proof_data = new uint8_t[8 * k];
-        uint8_t challenge[32];
-        size_t i;
-        memset(challenge, 155, 32);
-        vector<LargeBits> qualities;
-        for (i = 0; i < 50; i++) {
-            qualities = prover.GetQualitiesForChallenge(challenge);
-            if (qualities.size())
-                break;
-            challenge[0]++;
-        }
-        Verifier verifier = Verifier();
-        REQUIRE(qualities.size() > 0);
-        for (uint32_t index = 0; index < qualities.size(); index++) {
-            LargeBits proof = prover.GetFullProof(challenge, index);
-            proof.ToBytes(proof_data);
-            LargeBits quality = verifier.ValidateProof(plot_id_1, k, challenge, proof_data, k*8);
-            REQUIRE(quality == qualities[index]);
-        }
-        delete[] proof_data;
-        }
-        REQUIRE(remove(filename.c_str()) == 0);
-        REQUIRE_THROWS_WITH([&](){
-            DiskProver p(filename);
-        }(), "Invalid file " + filename);
-    }
-}
+// TEST_CASE("Invalid plot") {
+//     SECTION("File gets deleted") {
+//         string filename = "invalid-plot.dat";
+//         {
+//         DiskPlotter plotter = DiskPlotter();
+//         uint8_t memo[5] = {1, 2, 3, 4, 5};
+//         uint8_t k = 22;
+//         plotter.CreatePlotDisk(".", ".", ".", filename, k, memo, 5, plot_id_1, 32);
+//         DiskProver prover(filename);
+//         uint8_t* proof_data = new uint8_t[8 * k];
+//         uint8_t challenge[32];
+//         size_t i;
+//         memset(challenge, 155, 32);
+//         vector<LargeBits> qualities;
+//         for (i = 0; i < 50; i++) {
+//             qualities = prover.GetQualitiesForChallenge(challenge);
+//             if (qualities.size())
+//                 break;
+//             challenge[0]++;
+//         }
+//         Verifier verifier = Verifier();
+//         REQUIRE(qualities.size() > 0);
+//         for (uint32_t index = 0; index < qualities.size(); index++) {
+//             LargeBits proof = prover.GetFullProof(challenge, index);
+//             proof.ToBytes(proof_data);
+//             LargeBits quality = verifier.ValidateProof(plot_id_1, k, challenge, proof_data, k*8);
+//             REQUIRE(quality == qualities[index]);
+//         }
+//         delete[] proof_data;
+//         }
+//         REQUIRE(remove(filename.c_str()) == 0);
+//         REQUIRE_THROWS_WITH([&](){
+//             DiskProver p(filename);
+//         }(), "Invalid file " + filename);
+//     }
+// }
 
 TEST_CASE("Sort on disk") {
     SECTION("ExtractNum") {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -510,50 +510,50 @@ TEST_CASE("Plotting") {
     SECTION("Disk plot 1") {
         PlotAndTestProofOfSpace("cpp-test-plot.dat", 100, 16, plot_id_1);
     }
-    // SECTION("Disk plot 2") {
-    //     PlotAndTestProofOfSpace("cpp-test-plot.dat", 500, 17, plot_id_3);
-    // }
-    // SECTION("Disk plot 3") {
-    //     PlotAndTestProofOfSpace("cpp-test-plot.dat", 5000, 21, plot_id_3);
-    // }
+    SECTION("Disk plot 2") {
+        PlotAndTestProofOfSpace("cpp-test-plot.dat", 500, 17, plot_id_3);
+    }
+    SECTION("Disk plot 3") {
+        PlotAndTestProofOfSpace("cpp-test-plot.dat", 5000, 21, plot_id_3);
+    }
 }
 
-// TEST_CASE("Invalid plot") {
-//     SECTION("File gets deleted") {
-//         string filename = "invalid-plot.dat";
-//         {
-//         DiskPlotter plotter = DiskPlotter();
-//         uint8_t memo[5] = {1, 2, 3, 4, 5};
-//         uint8_t k = 22;
-//         plotter.CreatePlotDisk(".", ".", ".", filename, k, memo, 5, plot_id_1, 32);
-//         DiskProver prover(filename);
-//         uint8_t* proof_data = new uint8_t[8 * k];
-//         uint8_t challenge[32];
-//         size_t i;
-//         memset(challenge, 155, 32);
-//         vector<LargeBits> qualities;
-//         for (i = 0; i < 50; i++) {
-//             qualities = prover.GetQualitiesForChallenge(challenge);
-//             if (qualities.size())
-//                 break;
-//             challenge[0]++;
-//         }
-//         Verifier verifier = Verifier();
-//         REQUIRE(qualities.size() > 0);
-//         for (uint32_t index = 0; index < qualities.size(); index++) {
-//             LargeBits proof = prover.GetFullProof(challenge, index);
-//             proof.ToBytes(proof_data);
-//             LargeBits quality = verifier.ValidateProof(plot_id_1, k, challenge, proof_data, k*8);
-//             REQUIRE(quality == qualities[index]);
-//         }
-//         delete[] proof_data;
-//         }
-//         REQUIRE(remove(filename.c_str()) == 0);
-//         REQUIRE_THROWS_WITH([&](){
-//             DiskProver p(filename);
-//         }(), "Invalid file " + filename);
-//     }
-// }
+TEST_CASE("Invalid plot") {
+    SECTION("File gets deleted") {
+        string filename = "invalid-plot.dat";
+        {
+        DiskPlotter plotter = DiskPlotter();
+        uint8_t memo[5] = {1, 2, 3, 4, 5};
+        uint8_t k = 22;
+        plotter.CreatePlotDisk(".", ".", ".", filename, k, memo, 5, plot_id_1, 32);
+        DiskProver prover(filename);
+        uint8_t* proof_data = new uint8_t[8 * k];
+        uint8_t challenge[32];
+        size_t i;
+        memset(challenge, 155, 32);
+        vector<LargeBits> qualities;
+        for (i = 0; i < 50; i++) {
+            qualities = prover.GetQualitiesForChallenge(challenge);
+            if (qualities.size())
+                break;
+            challenge[0]++;
+        }
+        Verifier verifier = Verifier();
+        REQUIRE(qualities.size() > 0);
+        for (uint32_t index = 0; index < qualities.size(); index++) {
+            LargeBits proof = prover.GetFullProof(challenge, index);
+            proof.ToBytes(proof_data);
+            LargeBits quality = verifier.ValidateProof(plot_id_1, k, challenge, proof_data, k*8);
+            REQUIRE(quality == qualities[index]);
+        }
+        delete[] proof_data;
+        }
+        REQUIRE(remove(filename.c_str()) == 0);
+        REQUIRE_THROWS_WITH([&](){
+            DiskProver p(filename);
+        }(), "Invalid file " + filename);
+    }
+}
 
 TEST_CASE("Sort on disk") {
     SECTION("ExtractNum") {

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -13,10 +13,11 @@ class TestPythonBindings(unittest.TestCase):
                                   10, 11, 129, 139, 171, 15, 23])
 
         pl = DiskPlotter()
+        pl.create_plot_disk(".", ".", ".", "myplot.dat", 15, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
 
         pl.create_plot_disk(".", ".", ".", "myplot.dat", 17, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
 
-        pl.create_plot_disk(".", ".", ".", "myplot.dat", 21, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
+        # pl.create_plot_disk(".", ".", ".", "myplot.dat", 21, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
         pl = None
 
         pr = DiskProver(str(Path("myplot.dat")))

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -13,12 +13,7 @@ class TestPythonBindings(unittest.TestCase):
                                   10, 11, 129, 139, 171, 15, 23])
 
         pl = DiskPlotter()
-        pl.create_plot_disk(".", ".", ".", "myplot.dat", 14, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
-        pl.create_plot_disk(".", ".", ".", "myplot.dat", 15, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
-
-        # pl.create_plot_disk(".", ".", ".", "myplot.dat", 17, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
-
-        # pl.create_plot_disk(".", ".", ".", "myplot.dat", 21, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
+        pl.create_plot_disk(".", ".", ".", "myplot.dat", 21, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
         pl = None
 
         pr = DiskProver(str(Path("myplot.dat")))
@@ -38,20 +33,20 @@ class TestPythonBindings(unittest.TestCase):
                 assert computed_quality == quality
                 total_proofs += 1
 
-        # print(f"total proofs {total_proofs} out of {iterations}\
-        #     {total_proofs / iterations}")
-        # assert total_proofs > 4000
-        # assert total_proofs < 6000
-        # pr = None
-        # sha256_plot_hash = sha256()
-        # with open("myplot.dat", "rb") as f:
-        #     # Read and update hash string value in blocks of 4K
-        #     for byte_block in iter(lambda: f.read(4096), b""):
-        #         sha256_plot_hash.update(byte_block)
-        #     plot_hash = str(sha256_plot_hash.hexdigest())
-        # assert plot_hash == "80e32f560f3a4347760d6baae8d16fbaf484948088bff05c51bdcc24b7bc40d9"
-        # print(f"\nPlotfile asserted sha256: {plot_hash}\n")
-        # Path("myplot.dat").unlink()
+        print(f"total proofs {total_proofs} out of {iterations}\
+            {total_proofs / iterations}")
+        assert total_proofs > 4000
+        assert total_proofs < 6000
+        pr = None
+        sha256_plot_hash = sha256()
+        with open("myplot.dat", "rb") as f:
+            # Read and update hash string value in blocks of 4K
+            for byte_block in iter(lambda: f.read(4096), b""):
+                sha256_plot_hash.update(byte_block)
+            plot_hash = str(sha256_plot_hash.hexdigest())
+        assert plot_hash == "80e32f560f3a4347760d6baae8d16fbaf484948088bff05c51bdcc24b7bc40d9"
+        print(f"\nPlotfile asserted sha256: {plot_hash}\n")
+        Path("myplot.dat").unlink()
 
 
 if __name__ == '__main__':

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -13,6 +13,7 @@ class TestPythonBindings(unittest.TestCase):
                                   10, 11, 129, 139, 171, 15, 23])
 
         pl = DiskPlotter()
+        pl.create_plot_disk(".", ".", ".", "myplot.dat", 14, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
         pl.create_plot_disk(".", ".", ".", "myplot.dat", 15, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
 
         # pl.create_plot_disk(".", ".", ".", "myplot.dat", 17, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
@@ -37,20 +38,20 @@ class TestPythonBindings(unittest.TestCase):
                 assert computed_quality == quality
                 total_proofs += 1
 
-        print(f"total proofs {total_proofs} out of {iterations}\
-            {total_proofs / iterations}")
-        assert total_proofs > 4000
-        assert total_proofs < 6000
-        pr = None
-        sha256_plot_hash = sha256()
-        with open("myplot.dat", "rb") as f:
-            # Read and update hash string value in blocks of 4K
-            for byte_block in iter(lambda: f.read(4096), b""):
-                sha256_plot_hash.update(byte_block)
-            plot_hash = str(sha256_plot_hash.hexdigest())
-        assert plot_hash == "80e32f560f3a4347760d6baae8d16fbaf484948088bff05c51bdcc24b7bc40d9"
-        print(f"\nPlotfile asserted sha256: {plot_hash}\n")
-        Path("myplot.dat").unlink()
+        # print(f"total proofs {total_proofs} out of {iterations}\
+        #     {total_proofs / iterations}")
+        # assert total_proofs > 4000
+        # assert total_proofs < 6000
+        # pr = None
+        # sha256_plot_hash = sha256()
+        # with open("myplot.dat", "rb") as f:
+        #     # Read and update hash string value in blocks of 4K
+        #     for byte_block in iter(lambda: f.read(4096), b""):
+        #         sha256_plot_hash.update(byte_block)
+        #     plot_hash = str(sha256_plot_hash.hexdigest())
+        # assert plot_hash == "80e32f560f3a4347760d6baae8d16fbaf484948088bff05c51bdcc24b7bc40d9"
+        # print(f"\nPlotfile asserted sha256: {plot_hash}\n")
+        # Path("myplot.dat").unlink()
 
 
 if __name__ == '__main__':

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -13,6 +13,9 @@ class TestPythonBindings(unittest.TestCase):
                                   10, 11, 129, 139, 171, 15, 23])
 
         pl = DiskPlotter()
+
+        pl.create_plot_disk(".", ".", ".", "myplot.dat", 17, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
+
         pl.create_plot_disk(".", ".", ".", "myplot.dat", 21, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
         pl = None
 

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -15,7 +15,7 @@ class TestPythonBindings(unittest.TestCase):
         pl = DiskPlotter()
         pl.create_plot_disk(".", ".", ".", "myplot.dat", 15, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
 
-        pl.create_plot_disk(".", ".", ".", "myplot.dat", 17, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
+        # pl.create_plot_disk(".", ".", ".", "myplot.dat", 17, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
 
         # pl.create_plot_disk(".", ".", ".", "myplot.dat", 21, bytes([1, 2, 3, 4, 5]), plot_seed, 2*1024)
         pl = None


### PR DESCRIPTION
Implements rewriting of left tables during forward prop, to save working space. Also drops unused entries in forward prop. 
Overall seems to save 40-55%  in working space. Reduces total writes to ssd by up to 20%.

* Tmp files now separated into one table per file
* plot pointers removed, replaced with a vector of FileDisks
* Files truncated when stuff is not needed
* Fixed an edge case with reading and writing zeroes to the end of the tables
* Backprop slightly sped up by dropping entries, and sorting on more uniform data
* Positions stored in k bits instead of k+1
* Fix valgrind memory leaks/errors by Freeing ANS resources, and initializing memory

Slightly slows down overall plotting by around 3% due to forward prop CPU usage. Some optimizations still left to do here. 