### PR TITLE
Simplify and improve performance of F1 calculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,14 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(pybind11-src)
 
-set (CMAKE_CXX_FLAGS "-g -O3 -Wall -std=c++1z")
-set (CMAKE_C_FLAGS "-g -O3 -Wall")
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set (CMAKE_CXX_FLAGS "-g -O2 -Wall -std=c++1z")
+  set (CMAKE_C_FLAGS "-g -O2 -Wall")
+else()
+  set (CMAKE_CXX_FLAGS "-g -O3 -Wall -std=c++1z")
+  set (CMAKE_C_FLAGS "-g -O3 -Wall")
+endif()
+
 
 set(BLAKE3_SRC
     src/b3/blake3.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,13 +36,8 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(pybind11-src)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set (CMAKE_CXX_FLAGS "-g -O2 -Wall -std=c++1z")
-  set (CMAKE_C_FLAGS "-g -O2 -Wall")
-else()
-  set (CMAKE_CXX_FLAGS "-g -O3 -Wall -std=c++1z")
-  set (CMAKE_C_FLAGS "-g -O3 -Wall")
-endif()
+set (CMAKE_CXX_FLAGS "-g -O3 -Wall -std=c++1z")
+set (CMAKE_C_FLAGS "-g -O3 -Wall")
 
 
 set(BLAKE3_SRC

--- a/src/calculate_bucket.hpp
+++ b/src/calculate_bucket.hpp
@@ -77,7 +77,9 @@ public:
     inline F1Calculator(uint8_t k, const uint8_t* orig_key)
     {
         uint8_t enc_key[32];
+        size_t buf_blocks = CDIV((k + kExtraBits) << kBatchSizes, kF1BlockSizeBits) + 2;
         this->k_ = k;
+        this->buf_ = (uint8_t *)malloc(buf_blocks * kF1BlockSizeBits / 8);
 
         // First byte is 1, the index of this table
         enc_key[0] = 1;
@@ -87,7 +89,10 @@ public:
         chacha8_keysetup(&this->enc_ctx_, enc_key, 256, NULL);
     }
 
-    inline ~F1Calculator() {}
+    inline ~F1Calculator()
+    {
+        free(this->buf_);
+    }
 
     // Disable copying
     F1Calculator(const F1Calculator&) = delete;
@@ -154,69 +159,25 @@ public:
         return std::make_pair(CalculateF(L), L);
     }
 
-    // Returns an evaluation of F1(L), and the metadata (L) that must be stored to evaluate F2,
-    // for 'number_of_evaluations' adjacent inputs.
-    inline std::vector<std::pair<Bits, Bits>> CalculateBuckets(
-        const Bits& start_L,
-        uint64_t number_of_evaluations)
+    // F1(x) values for x in range [first_x, first_x + n) are placed in res[].
+    // n must not be more than 1 << kBatchSizes.
+    void CalculateBuckets(uint64_t first_x, uint64_t n, uint64_t *res)
     {
-        uint16_t num_output_bits = k_;
-        uint16_t block_size_bits = kF1BlockSizeBits;
+        uint64_t start = first_x * k_ / kF1BlockSizeBits;
+        uint64_t end = ((first_x + n + 1) * k_ - 1) / kF1BlockSizeBits;
+        uint64_t n_blks = end - start + 1;
+        uint32_t start_bit = first_x * k_ % kF1BlockSizeBits;
+        uint8_t x_shift = k_ - kExtraBits;
 
-        uint64_t two_to_the_k = (uint64_t)1 << k_;
-        if (start_L.GetValue() + number_of_evaluations > two_to_the_k) {
-            throw "Evaluation out of range";
+        chacha8_get_keystream(&this->enc_ctx_, start, n_blks, buf_);
+        for (uint64_t i = 0; i < n; i++) {
+            uint64_t x = first_x + i;
+            uint64_t y = Util::SliceInt64FromBytes(buf_, start_bit, k_);
+
+            res[i] = (y << kExtraBits) | (x >> x_shift);
+
+            start_bit += k_;
         }
-        // Counter for the first input
-        uint64_t counter = (start_L.GetValue() * (uint128_t)num_output_bits) / block_size_bits;
-        // Counter for the last input
-        uint64_t counter_end =
-            ((start_L.GetValue() + (uint128_t)number_of_evaluations + 1) * num_output_bits) /
-            block_size_bits;
-
-        std::vector<Bits> blocks;
-        uint64_t L = (counter * block_size_bits) / num_output_bits;
-        uint8_t ciphertext_bytes[kF1BlockSizeBits / 8];
-
-        // Evaluates ChaCha8 for each block
-        while (counter <= counter_end) {
-            chacha8_get_keystream(&this->enc_ctx_, counter, 1, ciphertext_bytes);
-            Bits ciphertext(ciphertext_bytes, block_size_bits / 8, block_size_bits);
-            blocks.push_back(std::move(ciphertext));
-            ++counter;
-        }
-
-        std::vector<std::pair<Bits, Bits>> results;
-        uint64_t block_number = 0;
-        uint16_t start_bit = (start_L.GetValue() * (uint128_t)num_output_bits) % block_size_bits;
-
-        // For each of the inputs, grabs the correct slice from the encrypted data.
-        for (L = start_L.GetValue(); L < start_L.GetValue() + number_of_evaluations; L++) {
-            Bits L_bits = Bits(L, k_);
-
-            // Takes the first kExtraBits bits from the input, and adds zeroes if it's not enough
-            Bits extra_data = L_bits.Slice(0, kExtraBits);
-            if (extra_data.GetSize() < kExtraBits) {
-                extra_data = extra_data + Bits(0, kExtraBits - extra_data.GetSize());
-            }
-
-            if (start_bit + num_output_bits < block_size_bits) {
-                // Everything can be sliced from the current block
-                results.push_back(std::make_pair(
-                    blocks[block_number].Slice(start_bit, start_bit + num_output_bits) + extra_data,
-                    L_bits));
-            } else {
-                // Must move forward one block
-                Bits left = blocks[block_number].Slice(start_bit);
-                Bits right = blocks[block_number + 1].Slice(
-                    0, num_output_bits - (block_size_bits - start_bit));
-                results.push_back(std::make_pair(left + right + extra_data, L_bits));
-                ++block_number;
-            }
-            // Start bit of the output slice in the current block
-            start_bit = (start_bit + num_output_bits) % block_size_bits;
-        }
-        return results;
     }
 
 private:
@@ -225,6 +186,8 @@ private:
 
     // ChaCha8 context
     struct chacha8_ctx enc_ctx_;
+
+    uint8_t *buf_;
 };
 
 struct rmap_item {

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -51,7 +51,7 @@ string Strip0x(const string &hex)
 void HelpAndQuit(cxxopts::Options options)
 {
     cout << options.help({""}) << endl;
-    cout << "./ProofOfSpace generate" << endl;
+    cout << "./ProofOfSpace create" << endl;
     cout << "./ProofOfSpace prove <challenge>" << endl;
     cout << "./ProofOfSpace verify <proof> <challenge>" << endl;
     cout << "./ProofOfSpace check" << endl;
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     try {
         cxxopts::Options options(
             "ProofOfSpace", "Utility for plotting, generating and verifying proofs of space.");
-        options.positional_help("(generate/prove/verify/check) param1 param2 ")
+        options.positional_help("(create/prove/verify/check) param1 param2 ")
             .show_positional_help();
 
         // Default values
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
 
         if (operation == "help") {
             HelpAndQuit(options);
-        } else if (operation == "generate") {
+        } else if (operation == "create") {
             cout << "Generating plot for k=" << static_cast<int>(k) << " filename=" << filename
                  << " id=" << id << endl
                  << endl;
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
             std::cout << "Total success: " << success << "/" << iterations << ", "
                       << (success * 100 / static_cast<double>(iterations)) << "%." << std::endl;
         } else {
-            cout << "Invalid operation. Use generate/prove/verify/check" << endl;
+            cout << "Invalid operation. Use create/prove/verify/check" << endl;
         }
         exit(0);
     } catch (const cxxopts::OptionException &e) {

--- a/src/phase1.hpp
+++ b/src/phase1.hpp
@@ -156,10 +156,10 @@ void* phase1_thread(void* arg)
     // Streams to read and right to tables. We will have handles to two tables. We will
     // read through the left table, compute matches, and evaluate f for matching entries,
     // writing results to the right table.
-    uint64_t left_buf_entries = (uint64_t)(globals.stripe_size) + 5000;
-    uint64_t right_buf_entries = (uint64_t)(globals.stripe_size) + 5000;
-    uint8_t* right_writer_buf = new uint8_t[right_buf_entries * right_entry_size_bytes];
-    uint8_t* left_writer_buf = new uint8_t[left_buf_entries * compressed_entry_size_bytes];
+    uint64_t left_buf_entries = 5000 + (uint64_t)((1.1)*(globals.stripe_size));
+    uint64_t right_buf_entries = 5000 + (uint64_t)((1.1)*(globals.stripe_size));
+    uint8_t* right_writer_buf = new uint8_t[right_buf_entries * right_entry_size_bytes]();
+    uint8_t* left_writer_buf = new uint8_t[left_buf_entries * compressed_entry_size_bytes]();
 
     FxCalculator f(k, table_index + 1);
 
@@ -168,8 +168,8 @@ void* phase1_thread(void* arg)
     uint16_t position_map_size = 2000;
 
     uint16_t* L_position_map =
-        new uint16_t[position_map_size];  // Should comfortably fit 2 buckets worth of items
-    uint16_t* R_position_map = new uint16_t[position_map_size];
+        new uint16_t[position_map_size]();  // Should comfortably fit 2 buckets worth of items
+    uint16_t* R_position_map = new uint16_t[position_map_size]();
 
     // Start at left table pos = 0 and iterate through the whole table. Note that the left table
     // will already be sorted by y

--- a/src/phase1.hpp
+++ b/src/phase1.hpp
@@ -588,6 +588,7 @@ std::vector<uint64_t> RunPhase1(
     F1Calculator f1(k, id);
     uint64_t x = 0;
     uint64_t prevtableentries = 0;
+    uint64_t *f1_entries = (uint64_t *)malloc((1 << kBatchSizes) * sizeof(*f1_entries));
 
     uint32_t t1_entry_size_bytes = EntrySizes::GetMaxEntrySize(k, 1, true);
     globals.L_sort_manager = new SortManager(
@@ -601,31 +602,27 @@ std::vector<uint64_t> RunPhase1(
         0,
         globals.stripe_size);
 
-    // The max value our input (x), can take. A proof of space is 64 of these x values.
-    uint64_t max_value = ((uint64_t)1 << (k)) - 1;
-
     // These are used for sorting on disk. The sort on disk code needs to know how
     // many elements are in each bucket.
     std::vector<uint64_t> table_sizes = std::vector<uint64_t>(8, 0);
 
     // Instead of computing f1(1), f1(2), etc, for each x, we compute them in batches
     // to increase CPU efficency.
-    for (uint64_t lp = 0; lp <= (((uint64_t)1) << (k - kBatchSizes)); lp++) {
-        // For each pair x, y in the batch
-        for (auto kv : f1.CalculateBuckets(Bits(x, k), 2 << (kBatchSizes - 1))) {
-            Bits to_write = std::get<0>(kv) + std::get<1>(kv);
-            globals.L_sort_manager->AddToCache(to_write);
-            prevtableentries++;
+    for (uint64_t lp = 0; lp < (uint64_t)1 << (k - kBatchSizes); lp++) {
+        f1.CalculateBuckets(x, 1 << kBatchSizes, f1_entries);
+        for (int i = 0; i < 1 << kBatchSizes; i++) {
+            uint8_t to_write[16];
+            uint128_t entry;
 
-            if (x + 1 > max_value) {
-                break;
-            }
-            ++x;
-        }
-        if (x + 1 > max_value) {
-            break;
+            entry = (uint128_t)f1_entries[i] << (128 - kExtraBits - k);
+            entry |= (uint128_t)x << (128 - kExtraBits - 2 * k);
+            Util::IntTo16Bytes(to_write, entry);
+            globals.L_sort_manager->AddToCache(to_write);
+            x++;
         }
     }
+    prevtableentries = 1ULL << k;
+    free(f1_entries);
     f1_start_time.PrintElapsed("F1 complete, time:");
     globals.L_sort_manager->FlushCache();
     table_sizes[1] = x + 1;

--- a/src/phase2.hpp
+++ b/src/phase2.hpp
@@ -78,7 +78,7 @@ std::vector<uint64_t> RunPhase2(
         uint64_t right_reader_buf_entries = sort_manager_buf_size / right_entry_size_bytes;
         uint64_t left_writer_buf_entries = left_writer_buf_size / left_entry_size_bytes;
         uint64_t right_writer_buf_entries = other_buf_sizes / right_entry_size_bytes;
-        uint64_t left_reader_buf_entries = other_buf_sizes / left_entry_size_bytes;
+        uint64_t left_reader_buf_entries = other_buf_sizes / left_entry_size_bytes - 10;
         uint64_t left_reader_count = 0;
         uint64_t right_reader_count = 0;
         uint64_t left_writer_count = 0;

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -190,7 +190,7 @@ Phase3Results RunPhase3(
         uint8_t *right_writer_buf = &(memory[sort_manager_buf_size]);
         uint8_t *right_reader_buf = &(memory[sort_manager_buf_size + right_writer_buf_size]);
         uint64_t left_reader_buf_entries = sort_manager_buf_size / left_entry_size_bytes;
-        uint64_t right_reader_buf_entries = right_reader_buf_size / right_entry_size_bytes;
+        uint64_t right_reader_buf_entries = right_reader_buf_size / right_entry_size_bytes - 10;
         uint64_t left_reader_count = 0;
         uint64_t right_reader_count = 0;
         uint64_t total_r_entries = 0;

--- a/src/sort_manager.hpp
+++ b/src/sort_manager.hpp
@@ -59,7 +59,6 @@ public:
         this->prev_bucket_buf_size =
             2 * (stripe_size + 10 * (kBC / pow(2, kExtraBits))) * entry_size;
         this->prev_bucket_buf = new uint8_t[this->prev_bucket_buf_size]();
-        std::cout << "SIze: " << prev_bucket_buf_size << std::endl;
         this->prev_bucket_position_start = 0;
         // Cross platform way to concatenate paths, gulrak library.
         std::vector<fs::path> bucket_filenames = std::vector<fs::path>();
@@ -224,7 +223,6 @@ private:
 
     inline void FlushTable(uint16_t bucket_i)
     {
-        std::cout << "Strart flush" << std::endl;
         uint64_t start_write = this->bucket_write_pointers[bucket_i];
         uint64_t write_len = this->mem_bucket_sizes[bucket_i] * this->entry_size;
 
@@ -235,12 +233,10 @@ private:
         // Reset memory caches
         this->mem_bucket_pointers[bucket_i] = this->memory_start + bucket_i * this->size_per_bucket;
         this->mem_bucket_sizes[bucket_i] = 0;
-        std::cout << "End flush" << std::endl;
     }
 
     inline void SortBucket(int quicksort)
     {
-        std::cout << "Start sort bucket" << std::endl;
         this->done = true;
         if (next_bucket_to_sort >= this->mem_bucket_pointers.size()) {
             throw InvalidValueException("Trying to sort bucket which does not exist.");
@@ -300,7 +296,6 @@ private:
         this->final_position_start = this->final_position_end;
         this->final_position_end += this->bucket_write_pointers[bucket_i];
         this->next_bucket_to_sort += 1;
-        std::cout << "Enzd sort bucket" << std::endl;
     }
 };
 

--- a/src/sort_manager.hpp
+++ b/src/sort_manager.hpp
@@ -58,7 +58,8 @@ public:
         this->done = false;
         this->prev_bucket_buf_size =
             2 * (stripe_size + 10 * (kBC / pow(2, kExtraBits))) * entry_size;
-        this->prev_bucket_buf = new uint8_t[this->prev_bucket_buf_size];
+        this->prev_bucket_buf = new uint8_t[this->prev_bucket_buf_size]();
+        std::cout << "SIze: " << prev_bucket_buf_size << std::endl;
         this->prev_bucket_position_start = 0;
         // Cross platform way to concatenate paths, gulrak library.
         std::vector<fs::path> bucket_filenames = std::vector<fs::path>();
@@ -79,7 +80,7 @@ public:
         this->final_position_start = 0;
         this->final_position_end = 0;
         this->next_bucket_to_sort = 0;
-        this->entry_buf = new uint8_t[entry_size];
+        this->entry_buf = new uint8_t[entry_size]();
     }
 
     inline void AddToCache(const Bits &entry)
@@ -223,6 +224,7 @@ private:
 
     inline void FlushTable(uint16_t bucket_i)
     {
+        std::cout << "Strart flush" << std::endl;
         uint64_t start_write = this->bucket_write_pointers[bucket_i];
         uint64_t write_len = this->mem_bucket_sizes[bucket_i] * this->entry_size;
 
@@ -233,10 +235,12 @@ private:
         // Reset memory caches
         this->mem_bucket_pointers[bucket_i] = this->memory_start + bucket_i * this->size_per_bucket;
         this->mem_bucket_sizes[bucket_i] = 0;
+        std::cout << "End flush" << std::endl;
     }
 
     inline void SortBucket(int quicksort)
     {
+        std::cout << "Start sort bucket" << std::endl;
         this->done = true;
         if (next_bucket_to_sort >= this->mem_bucket_pointers.size()) {
             throw InvalidValueException("Trying to sort bucket which does not exist.");
@@ -296,6 +300,7 @@ private:
         this->final_position_start = this->final_position_end;
         this->final_position_end += this->bucket_write_pointers[bucket_i];
         this->next_bucket_to_sort += 1;
+        std::cout << "Enzd sort bucket" << std::endl;
     }
 };
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -200,6 +200,14 @@ public:
         return bswap_64(i);
     }
 
+    static void IntTo16Bytes(uint8_t *result, const uint128_t input)
+    {
+        uint64_t r = bswap_64(input >> 64);
+        memcpy(result, &r, sizeof(r));
+        r = bswap_64((uint64_t)input);
+        memcpy(result + 8, &r, sizeof(r));
+    }
+
     /*
      * Retrieves the size of an integer, in Bits.
      */

--- a/src/verifier.hpp
+++ b/src/verifier.hpp
@@ -71,12 +71,11 @@ public:
         std::vector<Bits> proof;
         std::vector<Bits> ys;
         std::vector<Bits> metadata;
-        F1Calculator f1;
+        F1Calculator f1(k, id);
 
         for (uint8_t i = 0; i < 64; i++)
             proof.push_back(Bits(proof_bits.SliceBitsToInt(k * i, k * (i + 1)), k));
 
-        f1 = F1Calculator(k, id);
         // Calculates f1 for each of the given xs. Note that the proof is in proof order.
         for (uint8_t i = 0; i < 64; i++) {
             std::pair<Bits, Bits> results = f1.CalculateBucket(proof[i]);


### PR DESCRIPTION
Do not use Bits, provide F1 values in a simple array instead of a vector
of Bits. This increases performance of F1 calculation by several times.