### PR TITLE
address sanitizer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,15 @@ jobs:
         ctest -j 6
         valgrind --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=all ctest -j 6
 
+    - name: cmake, RunTests with address- and undefined sanitizer
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        mkdir build-asan
+        cd build-asan
+        cmake -DCMAKE_BUILD_TYPE=ASAN ../
+        cmake --build . -- -j 6
+        ./RunTests
+
     - name: Build wheels and test
       run: |
         python -m cibuildwheel --output-dir dist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,22 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(pybind11-src)
 
-set (CMAKE_CXX_FLAGS "-g -O3 -Wall")
-set (CMAKE_C_FLAGS "-g -O3 -Wall")
+IF (CMAKE_BUILD_TYPE STREQUAL "RELEASE")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
+ELSE()
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Og")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Og")
+ENDIF()
+
+IF (CMAKE_BUILD_TYPE STREQUAL "ASAN")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined")
+set (CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -Og -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined")
+ENDIF()
+
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -g")
 
 set(BLAKE3_SRC
     src/b3/blake3.c

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -220,14 +220,14 @@ public:
         uint32_t start_bit,
         const uint32_t num_bits)
     {
-        uint64_t tmp;
-
         if (start_bit + num_bits > 64) {
             bytes += start_bit / 8;
             start_bit %= 8;
         }
 
-        tmp = Util::EightBytesToInt(bytes);
+        uint64_t tmp = 0;
+        memcpy(&tmp, bytes, std::min(uint32_t(sizeof(uint64_t)), cdiv(start_bit + num_bits, 8)));
+        tmp = bswap_64(tmp);
         tmp <<= start_bit;
         tmp >>= 64 - num_bits;
         return tmp;

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -214,7 +214,10 @@ public:
         return count;
     }
 
-    /* Note: requires start_bit % 8 + num_bits <= 64 */
+    // bytes points to a big-endian 64 bit value (possibly truncated, if
+    // start_bit + num_bits < 64). Returns the integer that starts at start_bit
+    // that is num_bits long (as a native-endian integer).
+    // Note: requires start_bit % 8 + num_bits <= 64
     inline static uint64_t SliceInt64FromBytes(
         const uint8_t *bytes,
         uint32_t start_bit,

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -46,6 +46,105 @@ vector<unsigned char> intToBytes(uint32_t paramInt, uint32_t numBytes)
 
 static uint128_t to_uint128(uint64_t hi, uint64_t lo) { return (uint128_t)hi << 64 | lo; }
 
+TEST_CASE("SliceInt64FromBytes 1 bit")
+{
+    const uint8_t bytes[] = {0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9};
+
+    // since we interpret the first 64 bits (8 bytes) as big endian, the
+    // first byte is 0x01
+    CHECK(Util::SliceInt64FromBytes(bytes, 0, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 1, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 2, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 3, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 4, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 5, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 6, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 7, 1) == 1);
+
+    // the second byte is 0x2
+    CHECK(Util::SliceInt64FromBytes(bytes, 8, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 9, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 10, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 11, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 12, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 13, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 14, 1) == 1);
+    CHECK(Util::SliceInt64FromBytes(bytes, 15, 1) == 0);
+
+    // the third byte is 0x3
+    CHECK(Util::SliceInt64FromBytes(bytes, 16, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 17, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 18, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 19, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 20, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 21, 1) == 0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 22, 1) == 1);
+    CHECK(Util::SliceInt64FromBytes(bytes, 23, 1) == 1);
+}
+
+TEST_CASE("SliceInt64FromBytes 8 bits")
+{
+    const uint8_t bytes[] = {0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9};
+
+    // since we interpret the first 64 bits (8 bytes) as big endian, the
+    // first byte is 0x01
+    CHECK(Util::SliceInt64FromBytes(bytes, 0, 8) == 0b00000001);
+    CHECK(Util::SliceInt64FromBytes(bytes, 1, 8) == 0b00000010);
+    CHECK(Util::SliceInt64FromBytes(bytes, 2, 8) == 0b00000100);
+    CHECK(Util::SliceInt64FromBytes(bytes, 3, 8) == 0b00001000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 4, 8) == 0b00010000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 5, 8) == 0b00100000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 6, 8) == 0b01000000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 7, 8) == 0b10000001);
+
+    CHECK(Util::SliceInt64FromBytes(bytes,  8, 8) == 0b00000010);
+    CHECK(Util::SliceInt64FromBytes(bytes,  9, 8) == 0b00000100);
+    CHECK(Util::SliceInt64FromBytes(bytes, 10, 8) == 0b00001000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 11, 8) == 0b00010000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 12, 8) == 0b00100000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 13, 8) == 0b01000000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 14, 8) == 0b10000000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 15, 8) == 0b00000001);
+
+    CHECK(Util::SliceInt64FromBytes(bytes, 16, 8) == 0b00000011);
+    CHECK(Util::SliceInt64FromBytes(bytes, 17, 8) == 0b00000110);
+    CHECK(Util::SliceInt64FromBytes(bytes, 18, 8) == 0b00001100);
+    CHECK(Util::SliceInt64FromBytes(bytes, 19, 8) == 0b00011000);
+}
+
+TEST_CASE("SliceInt64FromBytes 24 bits")
+{
+    const uint8_t bytes[] = {0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9};
+
+    // since we interpret the first 64 bits (8 bytes) as big endian, the
+    // first byte is 0x01
+    CHECK(Util::SliceInt64FromBytes(bytes, 0, 24) == 0b00000001'00000010'00000011);
+    CHECK(Util::SliceInt64FromBytes(bytes, 1, 24) == 0b0000001'00000010'00000011'0);
+    CHECK(Util::SliceInt64FromBytes(bytes, 2, 24) == 0b000001'00000010'00000011'00);
+    CHECK(Util::SliceInt64FromBytes(bytes, 3, 24) == 0b00001'00000010'00000011'000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 4, 24) == 0b0001'00000010'00000011'0000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 5, 24) == 0b001'00000010'00000011'00000);
+    CHECK(Util::SliceInt64FromBytes(bytes, 6, 24) == 0b01'00000010'00000011'000001);
+    CHECK(Util::SliceInt64FromBytes(bytes, 7, 24) == 0b1'00000010'00000011'0000010);
+}
+
+TEST_CASE("SliceInt64FromBytesFull")
+{
+    const uint8_t bytes[] = {0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9};
+
+    // since we interpret the first 64 bits (8 bytes) as big endian, the
+    // first byte is 0x01
+    CHECK(Util::SliceInt64FromBytesFull(bytes, 0, 64) == 0x0102030405060708ull);
+    CHECK(Util::SliceInt64FromBytesFull(bytes, 1, 64) == 0x0102030405060708ull << 1);
+    CHECK(Util::SliceInt64FromBytesFull(bytes, 2, 64) == 0x0102030405060708ull << 2);
+    CHECK(Util::SliceInt64FromBytesFull(bytes, 3, 64) == 0x0102030405060708ull << 3);
+    CHECK(Util::SliceInt64FromBytesFull(bytes, 4, 64) == 0x1020304050607080ull);
+    CHECK(Util::SliceInt64FromBytesFull(bytes, 5, 64) == ((0x1020304050607080ull << 1) | 0b1));
+    CHECK(Util::SliceInt64FromBytesFull(bytes, 6, 64) == ((0x1020304050607080ull << 2) | 0b10));
+    CHECK(Util::SliceInt64FromBytesFull(bytes, 7, 64) == ((0x1020304050607080ull << 3) | 0b100));
+    CHECK(Util::SliceInt64FromBytesFull(bytes, 8, 64) == 0x0203040506070809ull);
+}
+
 TEST_CASE("Util")
 {
     SECTION("Increment and decrement")


### PR DESCRIPTION
run tests under address- and undefined sanitizers. Fix out-of-bounds read and add additional unit test cases to `SliceInt64FromBytes()`