### PR TITLE
remove using namespace std; from header file

### DIFF
--- a/src/bits.hpp
+++ b/src/bits.hpp
@@ -24,8 +24,6 @@
 #include "./util.hpp"
 #include "exceptions.hpp"
 
-using namespace std;
-
 // 64 * 2^16. 2^17 values, each value can store 64 bits.
 #define kMaxSizeBits 8388608
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -21,6 +21,11 @@
 #include "prover_disk.hpp"
 #include "verifier.hpp"
 
+using std::string;
+using std::vector;
+using std::endl;
+using std::cout;
+
 void HexToBytes(const string &hex, uint8_t *result)
 {
     for (uint32_t i = 0; i < hex.length(); i += 2) {
@@ -214,7 +219,7 @@ int main(int argc, char *argv[])
         } else if (operation == "check") {
             uint32_t iterations = 1000;
             if (argc == 3) {
-                iterations = stoi(argv[2]);
+                iterations = std::stoi(argv[2]);
             }
 
             DiskProver prover(filename);

--- a/src/encoding.hpp
+++ b/src/encoding.hpp
@@ -101,7 +101,7 @@ public:
                    dpdf[j] * (log2(ans[j] + 1) - log2(ans[j]));
         };
 
-        std::priority_queue<int, vector<int>, decltype(cmp)> pq(cmp);
+        std::priority_queue<int, std::vector<int>, decltype(cmp)> pq(cmp);
         for (int i = 0; i < N; ++i) pq.push(i);
 
         for (int todo = 0; todo < TOTAL_QUANTA - N; ++todo) {

--- a/src/entry_sizes.hpp
+++ b/src/entry_sizes.hpp
@@ -60,7 +60,7 @@ public:
                     //    a:  sort_key, pos, offset        or
                     //    b:  line_point, sort_key
                     return Util::ByteAlign(
-                               max(static_cast<uint32_t>(k + 1 + (k) + kOffsetSize),
+                               std::max(static_cast<uint32_t>(k + 1 + (k) + kOffsetSize),
                                    static_cast<uint32_t>(2 * k + k + 1))) /
                            8;
             case 7:

--- a/src/phase1.hpp
+++ b/src/phase1.hpp
@@ -681,7 +681,7 @@ std::vector<uint64_t> RunPhase1(
             log_num_buckets,
             right_entry_size_bytes,
             tmp_dirname,
-            filename + ".p1.t" + to_string(table_index + 1),
+            filename + ".p1.t" + std::to_string(table_index + 1),
             0,
             globals.stripe_size);
 

--- a/src/phase2.hpp
+++ b/src/phase2.hpp
@@ -95,7 +95,7 @@ std::vector<uint64_t> RunPhase2(
             log_num_buckets,
             left_entry_size_bytes,
             tmp_dirname,
-            filename + ".p2.t" + to_string(table_index - 1),
+            filename + ".p2.t" + std::to_string(table_index - 1),
             0,
             0);
 

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -25,7 +25,7 @@
 // can be properly built.
 struct Phase3Results {
     // Pointers to each table start byet in the final file
-    vector<uint64_t> final_table_begin_pointers;
+    std::vector<uint64_t> final_table_begin_pointers;
     // Number of entries written for f7
     uint64_t final_entries_written;
     uint32_t right_entry_size_bits;
@@ -206,7 +206,7 @@ Phase3Results RunPhase3(
             log_num_buckets,
             right_entry_size_bytes,
             tmp_dirname,
-            filename + ".p3.t" + to_string(table_index + 1),
+            filename + ".p3.t" + std::to_string(table_index + 1),
             0,
             0);
 
@@ -409,7 +409,7 @@ Phase3Results RunPhase3(
             log_num_buckets,
             right_entry_size_bytes,
             tmp_dirname,
-            filename + ".p3s.t" + to_string(table_index + 1),
+            filename + ".p3s.t" + std::to_string(table_index + 1),
             0,
             0);
 

--- a/src/phase4.hpp
+++ b/src/phase4.hpp
@@ -68,7 +68,7 @@ void RunPhase4(uint8_t k, uint8_t pos_size, FileDisk &tmp2_disk, Phase3Results &
     uint64_t prev_y = 0;
     std::vector<Bits> C2;
     uint64_t num_C1_entries = 0;
-    vector<uint8_t> deltas_to_write;
+    std::vector<uint8_t> deltas_to_write;
     uint32_t right_entry_size_bytes = res.right_entry_size_bits / 8;
 
     uint8_t *right_entry_buf;

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -105,7 +105,7 @@ public:
         // Subtract some ram to account for dynamic allocation through the code
         uint64_t thread_memory = num_threads * (2 * (stripe_size + 5000)) *
                                  EntrySizes::GetMaxEntrySize(k, 4, true) / (1024 * 1024);
-        uint64_t sub_mbytes = (5 + (int)min(buf_megabytes * 0.05, (double)50) + thread_memory);
+        uint64_t sub_mbytes = (5 + (int)std::min(buf_megabytes * 0.05, (double)50) + thread_memory);
         if (sub_mbytes > buf_megabytes) {
             throw InsufficientMemoryException(
                 "Please provide more memory. At least " + std::to_string(sub_mbytes));
@@ -163,7 +163,7 @@ public:
         tmp_1_filenames.push_back(fs::path(tmp_dirname) / fs::path(filename + ".sort.tmp"));
         for (size_t i = 1; i <= 7; i++) {
             tmp_1_filenames.push_back(
-                fs::path(tmp_dirname) / fs::path(filename + ".table" + to_string(i) + ".tmp"));
+                fs::path(tmp_dirname) / fs::path(filename + ".table" + std::to_string(i) + ".tmp"));
         }
         fs::path tmp_2_filename = fs::path(tmp2_dirname) / fs::path(filename + ".2.tmp");
         fs::path final_2_filename = fs::path(final_dirname) / fs::path(filename + ".2.tmp");

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -53,7 +53,7 @@ public:
         struct plot_header header;
         this->filename = filename;
 
-        ifstream disk_file(filename, std::ios::in | std::ios::binary);
+        std::ifstream disk_file(filename, std::ios::in | std::ios::binary);
 
         if (!disk_file.is_open()) {
             throw std::invalid_argument("Invalid file " + filename);
@@ -147,7 +147,7 @@ public:
         std::lock_guard<std::mutex> l(_mtx);
 
         {
-            ifstream disk_file(filename, std::ios::in | std::ios::binary);
+            std::ifstream disk_file(filename, std::ios::in | std::ios::binary);
 
             if (!disk_file.is_open()) {
                 throw std::invalid_argument("Invalid file " + filename);
@@ -185,11 +185,11 @@ public:
                 auto x1x2 = Encoding::LinePointToSquare(new_line_point);
 
                 // The final two x values (which are stored in the same location) are hashed
-                vector<unsigned char> hash_input(32 + Util::ByteAlign(2 * k) / 8, 0);
+                std::vector<unsigned char> hash_input(32 + Util::ByteAlign(2 * k) / 8, 0);
                 memcpy(hash_input.data(), challenge, 32);
                 (LargeBits(x1x2.second, k) + LargeBits(x1x2.first, k))
                     .ToBytes(hash_input.data() + 32);
-                vector<unsigned char> hash(picosha2::k_digest_size);
+                std::vector<unsigned char> hash(picosha2::k_digest_size);
                 picosha2::hash256(hash_input.begin(), hash_input.end(), hash.begin(), hash.end());
                 qualities.push_back(LargeBits(hash.data(), 32, 256));
             }
@@ -206,7 +206,7 @@ public:
 
         std::lock_guard<std::mutex> l(_mtx);
         {
-            ifstream disk_file(filename, std::ios::in | std::ios::binary);
+            std::ifstream disk_file(filename, std::ios::in | std::ios::binary);
 
             if (!disk_file.is_open()) {
                 throw std::invalid_argument("Invalid file " + filename);
@@ -246,7 +246,7 @@ private:
     // The entry at index "position" is read. First, the park index is calculated, then
     // the park is read, and finally, entry deltas are added up to the position that we
     // are looking for.
-    uint128_t ReadLinePoint(ifstream& disk_file, uint8_t table_index, uint64_t position)
+    uint128_t ReadLinePoint(std::ifstream& disk_file, uint8_t table_index, uint64_t position)
     {
         uint64_t park_index = position / kEntriesPerPark;
         uint32_t park_size_bits = EntrySizes::CalculateParkSize(k, table_index) * 8;
@@ -271,7 +271,7 @@ private:
         uint16_t encoded_deltas_size = 0;
         disk_file.read(reinterpret_cast<char*>(&encoded_deltas_size), sizeof(uint16_t));
 
-        vector<uint8_t> deltas;
+        std::vector<uint8_t> deltas;
 
         if (0x8000 & encoded_deltas_size) {
             // Uncompressed
@@ -348,7 +348,7 @@ private:
     }
 
     // Returns P7 table entries (which are positions into table P6), for a given challenge
-    std::vector<uint64_t> GetP7Entries(ifstream& disk_file, const uint8_t* challenge)
+    std::vector<uint64_t> GetP7Entries(std::ifstream& disk_file, const uint8_t* challenge)
     {
         if (C2.size() == 0) {
             return std::vector<uint64_t>();
@@ -545,7 +545,7 @@ private:
             LargeBits new_xs;
             // New results will be a list of pairs of (y, metadata), it will decrease in size by 2x
             // at each iteration of the outer loop.
-            std::vector<pair<Bits, Bits> > new_results;
+            std::vector<std::pair<Bits, Bits> > new_results;
             FxCalculator f(k, table_index);
             // Iterates through pairs of things, starts with 64 things, then 32, etc, up to 2.
             for (size_t i = 0; i < results.size(); i += 2) {
@@ -593,7 +593,7 @@ private:
     // all of the leaves (x values). For example, for depth=5, it fetches the position-th
     // entry in table 5, reading the two back pointers from the line point, and then
     // recursively calling GetInputs for table 4.
-    std::vector<Bits> GetInputs(ifstream& disk_file, uint64_t position, uint8_t depth)
+    std::vector<Bits> GetInputs(std::ifstream& disk_file, uint64_t position, uint8_t depth)
     {
         uint128_t line_point = ReadLinePoint(disk_file, depth, position);
         std::pair<uint64_t, uint64_t> xy = Encoding::LinePointToSquare(line_point);

--- a/src/sort_manager.hpp
+++ b/src/sort_manager.hpp
@@ -67,7 +67,7 @@ public:
             this->mem_bucket_pointers.push_back(memory + bucket_i * size_per_bucket);
             this->mem_bucket_sizes.push_back(0);
             this->bucket_write_pointers.push_back(0);
-            ostringstream bucket_number_padded;
+            std::ostringstream bucket_number_padded;
             bucket_number_padded << std::internal << std::setfill('0') << std::setw(3) << bucket_i;
 
             fs::path bucket_filename =
@@ -205,11 +205,11 @@ private:
     // Log of the number of buckets; num bits to use to determine bucket
     uint32_t log_num_buckets;
     // One pointer to the start of each bucket memory
-    vector<uint8_t *> mem_bucket_pointers;
+    std::vector<uint8_t *> mem_bucket_pointers;
     // The number of entries written to each bucket
-    vector<uint64_t> mem_bucket_sizes;
+    std::vector<uint64_t> mem_bucket_sizes;
     // The amount of data written to each disk bucket
-    vector<uint64_t> bucket_write_pointers;
+    std::vector<uint64_t> bucket_write_pointers;
     uint64_t prev_bucket_buf_size;
     uint8_t *prev_bucket_buf;
     uint64_t prev_bucket_position_start;
@@ -255,7 +255,7 @@ private:
         if (bucket_entries > entries_fit_in_memory) {
             throw InsufficientMemoryException(
                 "Not enough memory for sort in memory. Need to sort " +
-                to_string(this->bucket_write_pointers[bucket_i] / (1024.0 * 1024.0 * 1024.0)) +
+                std::to_string(this->bucket_write_pointers[bucket_i] / (1024.0 * 1024.0 * 1024.0)) +
                 "GiB");
         }
         bool last_bucket = (bucket_i == this->mem_bucket_pointers.size() - 1) ||

--- a/src/verifier.hpp
+++ b/src/verifier.hpp
@@ -47,10 +47,10 @@ public:
             proof = new_proof;
         }
         // Hashes two of the x values, based on the quality index
-        vector<unsigned char> hash_input(32 + Util::ByteAlign(2 * k) / 8, 0);
+        std::vector<unsigned char> hash_input(32 + Util::ByteAlign(2 * k) / 8, 0);
         memcpy(hash_input.data(), challenge, 32);
         proof.Slice(k * quality_index, k * (quality_index + 2)).ToBytes(hash_input.data() + 32);
-        vector<unsigned char> hash(picosha2::k_digest_size);
+        std::vector<unsigned char> hash(picosha2::k_digest_size);
         picosha2::hash256(hash_input.begin(), hash_input.end(), hash.begin(), hash.end());
         return LargeBits(hash.data(), 32, 256);
     }
@@ -94,8 +94,8 @@ public:
                 PlotEntry r_plot_entry;
                 l_plot_entry.y = ys[i].GetValue();
                 r_plot_entry.y = ys[i + 1].GetValue();
-                vector<PlotEntry> bucket_L = {l_plot_entry};
-                vector<PlotEntry> bucket_R = {r_plot_entry};
+                std::vector<PlotEntry> bucket_L = {l_plot_entry};
+                std::vector<PlotEntry> bucket_R = {r_plot_entry};
 
                 // If there is no match, fails.
                 uint64_t cdiff = r_plot_entry.y / kBC - l_plot_entry.y / kBC;


### PR DESCRIPTION
pulling in all of `std` in a header causes name clashes and generally makes code more brittle. This was causing name clashes in a different patch I'm working on.