### PR TITLE
F1 optimization v2

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -201,6 +201,14 @@ namespace Util {
         return bswap_64(i);
     }
 
+    static void IntTo16Bytes(uint8_t *result, const uint128_t input)
+    {
+        uint64_t r = bswap_64(input >> 64);
+        memcpy(result, &r, sizeof(r));
+        r = bswap_64((uint64_t)input);
+        memcpy(result + 8, &r, sizeof(r));
+    }
+
     /*
      * Retrieves the size of an integer, in Bits.
      */

--- a/src/verifier.hpp
+++ b/src/verifier.hpp
@@ -71,12 +71,11 @@ public:
         std::vector<Bits> proof;
         std::vector<Bits> ys;
         std::vector<Bits> metadata;
-        F1Calculator f1;
+        F1Calculator f1(k, id);
 
         for (uint8_t i = 0; i < 64; i++)
             proof.push_back(Bits(proof_bits.SliceBitsToInt(k * i, k * (i + 1)), k));
 
-        f1 = F1Calculator(k, id);
         // Calculates f1 for each of the given xs. Note that the proof is in proof order.
         for (uint8_t i = 0; i < 64; i++) {
             std::pair<Bits, Bits> results = f1.CalculateBucket(proof[i]);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -397,11 +397,13 @@ TEST_CASE("F functions")
         Bits L3 = Bits(625, test_k);
         pair<Bits, Bits> result3 = f1.CalculateBucket(L3);
 
-        vector<pair<Bits, Bits>> results = f1.CalculateBuckets(L, 101);
-        REQUIRE(result1 == results[0]);
-        REQUIRE(result2 == results[1]);
-        REQUIRE(result3 == results[100]);
+        uint64_t results[256];
+        f1.CalculateBuckets(L.GetValue(), 101, results);
+        REQUIRE(result1.first.GetValue() == results[0]);
+        REQUIRE(result2.first.GetValue() == results[1]);
+        REQUIRE(result3.first.GetValue() == results[100]);
 
+        uint32_t max_batch = 1 << kBatchSizes;
         test_k = 32;
         F1Calculator f1_2(test_k, test_key);
         L = Bits(192837491, test_k);
@@ -410,14 +412,14 @@ TEST_CASE("F functions")
         result2 = f1_2.CalculateBucket(L2);
         L3 = Bits(192837491 + 2, test_k);
         result3 = f1_2.CalculateBucket(L3);
-        Bits L4 = Bits(192837491 + 490, test_k);
+        Bits L4 = Bits(192837491 + max_batch - 1, test_k);
         pair<Bits, Bits> result4 = f1_2.CalculateBucket(L4);
 
-        results = f1_2.CalculateBuckets(L, 491);
-        REQUIRE(result1 == results[0]);
-        REQUIRE(result2 == results[1]);
-        REQUIRE(result3 == results[2]);
-        REQUIRE(result4 == results[490]);
+        f1_2.CalculateBuckets(L.GetValue(), max_batch, results);
+        REQUIRE(result1.first.GetValue() == results[0]);
+        REQUIRE(result2.first.GetValue() == results[1]);
+        REQUIRE(result3.first.GetValue() == results[2]);
+        REQUIRE(result4.first.GetValue() == results[max_batch - 1]);
     }
 
     SECTION("F2")
@@ -433,12 +435,15 @@ TEST_CASE("F functions")
 
         F1Calculator f1(k, test_key_2);
         for (uint32_t j = 0; j < (1ULL << (k - 4)) + 1; j++) {
-            for (auto pair : f1.CalculateBuckets(Bits(x, k), 1U << 4)) {
-                uint64_t bucket = std::get<0>(pair).GetValue() / kBC;
+            uint64_t y[1 << 4];
+
+            f1.CalculateBuckets(x, 1U << 4, y);
+            for (int i = 0; i < 1 << 4; i++) {
+                uint64_t bucket = y[i] / kBC;
                 if (buckets.find(bucket) == buckets.end()) {
                     buckets[bucket] = vector<std::pair<Bits, Bits>>();
                 }
-                buckets[bucket].push_back(pair);
+                buckets[bucket].push_back(std::make_pair(Bits(y[i], k + kExtraBits), Bits(x, k)));
                 if (x + 1 > (1ULL << k) - 1) {
                     break;
                 }


### PR DESCRIPTION
Do not use Bits, provide F1 values in a simple array instead of a vector
of Bits. This increases performance of F1 calculation several times.

Changes in v2: do not use malloc, other small changes based on Arvid's feedback, rebase on master