### PR TITLE
hack filesystem to work around issue in parsing mount-points

### DIFF
--- a/lib/include/filesystem.hpp
+++ b/lib/include/filesystem.hpp
@@ -1663,9 +1663,9 @@ GHC_INLINE void path::postprocess_path_with_format(path::impl_string_type& p, pa
                         p[0] = '\\';
                     }
                 }
-                else if (detail::startsWith(p, std::string("\\??\\"))) {
-                    p.erase(0, 4);
-                }
+//                else if (detail::startsWith(p, std::string("\\??\\"))) {
+//                    p.erase(0, 4);
+//                }
             }
             for (auto& c : p) {
                 if (c == '\\') {


### PR DESCRIPTION
This will fix the specific issue reported here: https://github.com/Chia-Network/chiapos/issues/103
However, I have not reviewed all our use of the filesystem to ensure this won't break anything else.
It's likely to break *some* uses of the filesystem library, I think it's mostly exotic use though.

I only run windows in a VM, so I have not even smoke tested this patch. Someone on windows should do that before we land it.
