### PR TITLE
sort_manager "quicksort" parameter

### DIFF
--- a/src/phase1.hpp
+++ b/src/phase1.hpp
@@ -226,7 +226,7 @@ void* phase1_thread(THREADDATA* ptd)
             if (!first_thread) {
                 Sem::Wait(ptd->theirs);
             }
-            globals.L_sort_manager->TriggerNewBucket(left_reader, 0);
+            globals.L_sort_manager->TriggerNewBucket(left_reader);
         }
         if (!last_thread) {
             // Do not post if we are the last thread, because first thread has already
@@ -740,7 +740,7 @@ std::vector<uint64_t> RunPhase1(
             0,
             globals.stripe_size);
 
-        globals.L_sort_manager->TriggerNewBucket(0, 0);
+        globals.L_sort_manager->TriggerNewBucket(0);
 
         Timer computation_pass_timer;
 

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -208,7 +208,8 @@ Phase3Results RunPhase3(
             tmp_dirname,
             filename + ".p3.t" + std::to_string(table_index + 1),
             0,
-            0);
+            0,
+            strategy_t::quicksort_last);
 
         bool should_read_entry = true;
         std::vector<uint64_t> left_new_pos(kCachedPositionsSize);
@@ -408,7 +409,8 @@ Phase3Results RunPhase3(
             tmp_dirname,
             filename + ".p3s.t" + std::to_string(table_index + 1),
             0,
-            0);
+            0,
+            strategy_t::quicksort);
 
         std::vector<uint8_t> park_deltas;
         std::vector<uint64_t> park_stubs;

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -312,7 +312,7 @@ Phase3Results RunPhase3(
                             left_reader_buf +
                             (left_reader_count % left_reader_buf_entries) * left_entry_size_bytes;
                     } else {
-                        left_entry_disk_buf = L_sort_manager->ReadEntry(left_reader, 1);
+                        left_entry_disk_buf = L_sort_manager->ReadEntry(left_reader);
                         left_reader += left_entry_size_bytes;
                     }
                     left_reader_count++;
@@ -426,7 +426,7 @@ Phase3Results RunPhase3(
         Bits right_entry_bits;
         int added_to_cache = 0;
         for (uint64_t index = 0; index < total_r_entries; index++) {
-            right_reader_entry_buf = R_sort_manager->ReadEntry(right_reader, 2);
+            right_reader_entry_buf = R_sort_manager->ReadEntry(right_reader);
             right_reader += right_entry_size_bytes;
             right_reader_count++;
 

--- a/src/phase4.hpp
+++ b/src/phase4.hpp
@@ -83,7 +83,7 @@ void RunPhase4(uint8_t k, uint8_t pos_size, FileDisk &tmp2_disk, Phase3Results &
     // We read each table7 entry, which is sorted by f7, but we don't need f7 anymore. Instead,
     // we will just store pos6, and the deltas in table C3, and checkpoints in tables C1 and C2.
     for (uint64_t f7_position = 0; f7_position < res.final_entries_written; f7_position++) {
-        right_entry_buf = res.table7_sm->ReadEntry(plot_file_reader, 1);
+        right_entry_buf = res.table7_sm->ReadEntry(plot_file_reader);
 
         plot_file_reader += right_entry_size_bytes;
         uint64_t entry_y = Util::SliceInt64FromBytes(right_entry_buf, 0, k);


### PR DESCRIPTION
This change makes the sort strategy (uniform sort, quicksort, or quicksort last bucket) a property of the sort manager, rather than a parameter to `ReadEntry()` et.al.

Partly this is a simplification, but it also prepares the sort manager to implement the Disk interface, where `Read()` doesn't want to have to care about which sorting should be used.

It's split up into two commits, as it was developed in two steps:

1. introduce the constructor parameter and member to store the sorting strategy. Assert that whatever argument is passed to `ReadEntry()` matches the member, and all tests pass.
2. Remove the member.

This is intended to not introduce any functional differences, just how and where in the code the sorting is determined.