### PR TITLE
bitfield optimization of phase2

### DIFF
--- a/.github/workflows/build-test-cplusplus.yml
+++ b/.github/workflows/build-test-cplusplus.yml
@@ -31,8 +31,8 @@ jobs:
         cd build
         cmake ../
         cmake --build . -- -j 6
-        ctest -j 6
-        valgrind --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=all ctest -j 6
+        ctest -j 6 --output-on-failure
+        valgrind --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=all ctest -j 6 --output-on-failure
 
     - name: cmake, RunTests with address- and undefined sanitizer on Ubuntu
       if: startsWith(matrix.os, 'ubuntu')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,11 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(pybind11-src)
 
 IF (CMAKE_BUILD_TYPE STREQUAL "RELEASE")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -mtune=native")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -mtune=native")
 ELSE()
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Og")
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Og")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
 ENDIF()
 
 IF (CMAKE_BUILD_TYPE STREQUAL "ASAN")

--- a/src/bitfield.hpp
+++ b/src/bitfield.hpp
@@ -78,6 +78,12 @@ struct bitfield
         }
         return ret;
     }
+
+    void free_memory()
+    {
+        buffer_.reset();
+        size_ = 0;
+    }
 private:
     std::unique_ptr<uint64_t[]> buffer_;
 

--- a/src/bitfield.hpp
+++ b/src/bitfield.hpp
@@ -1,0 +1,89 @@
+// Copyright 2020 Chia Network Inc
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+struct bitfield
+{
+    bitfield(uint8_t* buffer, int64_t num_bytes)
+        : buffer_(reinterpret_cast<uint64_t*>(buffer))
+        , size_(num_bytes / 8)
+    {
+        // we want this buffer to be 8-byte aligned
+        // both the pointer and size
+        assert((uintptr_t(buffer) & 7) == 0);
+        assert((num_bytes % 8) == 0);
+
+        clear();
+    }
+
+    void set(int64_t const bit)
+    {
+        assert(bit / 64 < size_);
+        buffer_[bit / 64] |= uint64_t(1) << (bit % 64);
+    }
+
+    bool get(int64_t const bit) const
+    {
+        assert(bit / 64 < size_);
+        return (buffer_[bit / 64] & (uint64_t(1) << (bit % 64))) != 0;
+    }
+
+    void clear()
+    {
+        std::memset(buffer_, 0, size_ * 8);
+    }
+
+    int64_t size() const { return size_ * 64; }
+
+    void swap(bitfield& rhs)
+    {
+        using std::swap;
+        swap(buffer_, rhs.buffer_);
+        swap(size_, rhs.size_);
+    }
+
+    int64_t count(int64_t const start_bit, int64_t const end_bit) const
+    {
+        assert((start_bit % 64) == 0);
+        assert(start_bit <= end_bit);
+
+        uint64_t const* start = buffer_ + start_bit / 64;
+        uint64_t const* end = buffer_ + end_bit / 64;
+        int64_t ret = 0;
+        while (start != end) {
+#ifdef _MSC_VER
+            ret += __popcnt64(*start);
+#else
+            ret += __builtin_popcountl(*start);
+#endif
+            ++start;
+        }
+        int const tail = end_bit % 64;
+        if (tail > 0) {
+            uint64_t const mask = (uint64_t(1) << tail) - 1;
+#ifdef _MSC_VER
+            ret += __popcnt64(*end & mask);
+#else
+            ret += __builtin_popcountl(*end & mask);
+#endif
+        }
+        return ret;
+    }
+private:
+    uint64_t* buffer_;
+
+    // number of 64-bit words
+    int64_t size_;
+};

--- a/src/bitfield_index.hpp
+++ b/src/bitfield_index.hpp
@@ -1,0 +1,63 @@
+// Copyright 2020 Chia Network Inc
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+
+struct bitfield_index
+{
+    // cache the number of set bits evey n bits. This is n. For a bitfield of
+    // size 2^32, this means a 2 MiB index
+    static inline const int64_t kIndexBucket = 16 * 1024;
+
+    bitfield_index(std::vector<bool> const& b) : bitfield_(b)
+    {
+        uint64_t counter = 0;
+        auto it = bitfield_.begin();
+        index_.reserve(bitfield_.size() / kIndexBucket);
+
+        for (int64_t idx = 0; idx < int64_t(bitfield_.size()); idx += kIndexBucket) {
+            index_.push_back(counter);
+            int64_t const left = std::min(int64_t(bitfield_.size()) - idx, kIndexBucket);
+            counter += std::count(it, it + left, true);
+            it += left;
+        }
+    }
+
+    std::pair<uint64_t, uint64_t> lookup(uint64_t pos, uint64_t offset) const
+    {
+        uint64_t const bucket = pos / kIndexBucket;
+
+        assert(bucket < index_.size());
+        assert(pos < bitfield_.size());
+        assert(pos + offset < bitfield_.size());
+
+        uint64_t const base = index_[bucket];
+
+        uint64_t const diff = std::count(
+                bitfield_.begin() + (bucket * kIndexBucket), bitfield_.begin() + pos, true);
+        uint64_t const new_offset = std::count(
+            bitfield_.begin() + pos
+            , bitfield_.begin() + pos + offset, true);
+
+        assert(new_offset <= offset);
+
+        return { base + diff, new_offset };
+    }
+private:
+    std::vector<bool> const& bitfield_;
+    std::vector<uint64_t> index_;
+};
+

--- a/src/disk.hpp
+++ b/src/disk.hpp
@@ -54,10 +54,12 @@ struct Disk {
 };
 
 #if ENABLE_LOGGING
+#include <mutex>
 #include <unordered_map>
 #include <cinttypes>
 
-enum class op_t { read, write};
+enum class op_t : int { read, write};
+
 void disk_log(fs::path const& filename, op_t const op, uint64_t offset, uint64_t length)
 {
     static std::mutex m;
@@ -90,7 +92,7 @@ void disk_log(fs::path const& filename, op_t const op, uint64_t offset, uint64_t
         , std::chrono::duration_cast<std::chrono::milliseconds>(timestamp).count()
         , offset
         , offset + length
-        , op
+        , int(op)
         , index);
     ::write(fd, buffer, len);
     ::close(fd);

--- a/src/disk.hpp
+++ b/src/disk.hpp
@@ -40,15 +40,15 @@ namespace fs = ghc::filesystem;
 #include "./bits.hpp"
 #include "./util.hpp"
 
+constexpr uint64_t write_cache = 4 * 1024 * 1024;
+constexpr uint64_t read_ahead = 4 * 1024 * 1024;
+
 struct Disk {
-    virtual void Read(uint64_t begin, uint8_t *memcache, uint64_t length) = 0;
-
+    virtual uint8_t const* Read(uint64_t begin, uint64_t length) = 0;
     virtual void Write(uint64_t begin, const uint8_t *memcache, uint64_t length) = 0;
-
     virtual void Truncate(uint64_t new_size) = 0;
-
     virtual std::string GetFileName() = 0;
-
+    virtual void FreeMemory() = 0;
     virtual ~Disk() = default;
 };
 
@@ -96,7 +96,7 @@ void disk_log(fs::path const& filename, op_t const op, uint64_t offset, uint64_t
 }
 #endif
 
-struct FileDisk : Disk {
+struct FileDisk {
     explicit FileDisk(const fs::path &filename)
     {
         filename_ = filename;
@@ -128,7 +128,7 @@ struct FileDisk : Disk {
 
     ~FileDisk() { Close(); }
 
-    void Read(uint64_t begin, uint8_t *memcache, uint64_t length) override
+    void Read(uint64_t begin, uint8_t *memcache, uint64_t length)
     {
 #if ENABLE_LOGGING
         disk_log(filename_, op_t::read, begin, length);
@@ -157,7 +157,7 @@ struct FileDisk : Disk {
         } while (amtread != length);
     }
 
-    void Write(uint64_t begin, const uint8_t *memcache, uint64_t length) override
+    void Write(uint64_t begin, const uint8_t *memcache, uint64_t length)
     {
 #if ENABLE_LOGGING
         disk_log(filename_, op_t::write, begin, length);
@@ -189,11 +189,11 @@ struct FileDisk : Disk {
         } while (amtwritten != length);
     }
 
-    std::string GetFileName() override { return filename_.string(); }
+    std::string GetFileName() { return filename_.string(); }
 
     uint64_t GetWriteMax() const noexcept { return writeMax; }
 
-    void Truncate(uint64_t new_size) override
+    void Truncate(uint64_t new_size)
     {
         Close();
         fs::resize_file(filename_, new_size);
@@ -217,45 +217,58 @@ private:
 
 struct BufferedDisk : Disk
 {
-    BufferedDisk(Disk* disk, uint64_t file_size) : disk_(disk), file_size_(file_size) {}
+    BufferedDisk(FileDisk* disk, uint64_t file_size) : disk_(disk), file_size_(file_size) {}
 
-    void Read(uint64_t begin, uint8_t *memcache, uint64_t length) override
+    uint8_t const* Read(uint64_t begin, uint64_t length) override
     {
-        if (read_buffer_start_ <= begin && read_buffer_start_ + read_buffer_size_ >= begin + length) {
-            // if the read is entirely inside the buffer, just memcopy it out
-            ::memcpy(memcache, read_buffer_ + (begin - read_buffer_start_), length);
+        assert(length < read_ahead);
+        NeedReadCache();
+        // all allocations need 7 bytes head-room, since
+        // SliceInt64FromBytes() may overrun by 7 bytes
+        if (read_buffer_start_ <= begin && read_buffer_start_ + read_buffer_size_ > begin + length + 7) {
+            // if the read is entirely inside the buffer, just return it
+            return read_buffer_.get() + (begin - read_buffer_start_);
         }
-        else if (begin >= read_buffer_start_ + read_buffer_size_ || begin == 0) {
+        else if (begin >= read_buffer_start_ || begin == 0) {
             // if the read is beyond the current buffer (i.e.
             // forward-sequential) move the buffer forward and read the next
             // buffer-capacity number of bytes
             read_buffer_start_ = begin;
-            uint64_t const amount_to_read = std::min(file_size_ - read_buffer_start_, read_buffer_capacity_);
-            disk_->Read(begin, read_buffer_, amount_to_read);
+            uint64_t const amount_to_read = std::min(file_size_ - read_buffer_start_, read_ahead);
+            disk_->Read(begin, read_buffer_.get(), amount_to_read);
             read_buffer_size_ = amount_to_read;
-            ::memcpy(memcache, read_buffer_ + (begin - read_buffer_start_), length);
+            return read_buffer_.get();
         }
         else {
+            // ideally this won't happen
+            assert(false);
+            static uint8_t temp[128];
+            // all allocations need 7 bytes head-room, since
+            // SliceInt64FromBytes() may overrun by 7 bytes
+            assert(length <= sizeof(temp) - 7);
+
             // if we're going backwards, don't wipe out the cache. We assume
             // forward sequential access
-            disk_->Read(begin, memcache, length);
+            disk_->Read(begin, temp, length);
+            return temp;
         }
     }
 
     void Write(uint64_t const begin, const uint8_t *memcache, uint64_t const length) override
     {
+        NeedWriteCache();
         if (begin == write_buffer_start_ + write_buffer_size_) {
-            if (write_buffer_size_ + length <= write_buffer_capacity_) {
-                ::memcpy(write_buffer_ + write_buffer_size_, memcache, length);
+            if (write_buffer_size_ + length <= write_cache) {
+                ::memcpy(write_buffer_.get() + write_buffer_size_, memcache, length);
                 write_buffer_size_ += length;
                 return;
             }
             TryFlushWriteCache();
         }
 
-        if (write_buffer_size_ == 0 && write_buffer_capacity_ >= length) {
+        if (write_buffer_size_ == 0 && write_cache >= length) {
             write_buffer_start_ = begin;
-            ::memcpy(write_buffer_ + write_buffer_size_, memcache, length);
+            ::memcpy(write_buffer_.get() + write_buffer_size_, memcache, length);
             write_buffer_size_ = length;
             return;
         }
@@ -268,52 +281,59 @@ struct BufferedDisk : Disk
         TryFlushWriteCache();
         disk_->Truncate(new_size);
         file_size_ = new_size;
+        FreeMemory();
     }
 
     std::string GetFileName() override { return disk_->GetFileName(); }
 
-    void SetReadCache(uint8_t* buffer, uint64_t size)
+    void FreeMemory() override
     {
-        read_buffer_ = buffer;
-        read_buffer_capacity_ = size;
-        read_buffer_start_ = -1;
+        read_buffer_.reset();
+        write_buffer_.reset();
         read_buffer_size_ = 0;
-    }
-
-    void SetWriteCache(uint8_t* buffer, uint64_t size)
-    {
-        write_buffer_ = buffer;
-        write_buffer_capacity_ = size;
-        write_buffer_start_ = -1;
         write_buffer_size_ = 0;
     }
 
 private:
 
+    void NeedReadCache()
+    {
+        if (read_buffer_) return;
+        read_buffer_.reset(new uint8_t[read_ahead]);
+        read_buffer_start_ = -1;
+        read_buffer_size_ = 0;
+    }
+
+    void NeedWriteCache()
+    {
+        if (write_buffer_) return;
+        write_buffer_.reset(new uint8_t[write_cache]);
+        write_buffer_start_ = -1;
+        write_buffer_size_ = 0;
+    }
+
     void TryFlushWriteCache()
     {
         if (write_buffer_size_ == 0) return;
 
-        disk_->Write(write_buffer_start_, write_buffer_, write_buffer_size_);
+        disk_->Write(write_buffer_start_, write_buffer_.get(), write_buffer_size_);
         write_buffer_size_ = 0;
     }
 
-    Disk* disk_;
+    FileDisk* disk_;
 
     uint64_t file_size_;
 
     // the file offset the read buffer was read from
     uint64_t read_buffer_start_ = -1;
-    uint8_t* read_buffer_ = nullptr;
+    std::unique_ptr<uint8_t[]> read_buffer_;
     uint64_t read_buffer_size_ = 0;
-    uint64_t read_buffer_capacity_ = 0;
 
     // the file offset the write buffer should be written back to
     // the write buffer is *only* for contiguous and sequential writes
     uint64_t write_buffer_start_ = -1;
-    uint8_t* write_buffer_ = nullptr;
+    std::unique_ptr<uint8_t[]> write_buffer_;
     uint64_t write_buffer_size_ = 0;
-    uint64_t write_buffer_capacity_ = 0;
 };
 
 #endif  // SRC_CPP_DISK_HPP_

--- a/src/disk.hpp
+++ b/src/disk.hpp
@@ -215,4 +215,105 @@ private:
     FILE *f_;
 };
 
+struct BufferedDisk : Disk
+{
+    BufferedDisk(Disk* disk, uint64_t file_size) : disk_(disk), file_size_(file_size) {}
+
+    void Read(uint64_t begin, uint8_t *memcache, uint64_t length) override
+    {
+        if (read_buffer_start_ <= begin && read_buffer_start_ + read_buffer_size_ >= begin + length) {
+            // if the read is entirely inside the buffer, just memcopy it out
+            ::memcpy(memcache, read_buffer_ + (begin - read_buffer_start_), length);
+        }
+        else if (begin >= read_buffer_start_ + read_buffer_size_ || begin == 0) {
+            // if the read is beyond the current buffer (i.e.
+            // forward-sequential) move the buffer forward and read the next
+            // buffer-capacity number of bytes
+            read_buffer_start_ = begin;
+            uint64_t const amount_to_read = std::min(file_size_ - read_buffer_start_, read_buffer_capacity_);
+            disk_->Read(begin, read_buffer_, amount_to_read);
+            read_buffer_size_ = amount_to_read;
+            ::memcpy(memcache, read_buffer_ + (begin - read_buffer_start_), length);
+        }
+        else {
+            // if we're going backwards, don't wipe out the cache. We assume
+            // forward sequential access
+            disk_->Read(begin, memcache, length);
+        }
+    }
+
+    void Write(uint64_t const begin, const uint8_t *memcache, uint64_t const length) override
+    {
+        if (begin == write_buffer_start_ + write_buffer_size_) {
+            if (write_buffer_size_ + length <= write_buffer_capacity_) {
+                ::memcpy(write_buffer_ + write_buffer_size_, memcache, length);
+                write_buffer_size_ += length;
+                return;
+            }
+            TryFlushWriteCache();
+        }
+
+        if (write_buffer_size_ == 0 && write_buffer_capacity_ >= length) {
+            write_buffer_start_ = begin;
+            ::memcpy(write_buffer_ + write_buffer_size_, memcache, length);
+            write_buffer_size_ = length;
+            return;
+        }
+
+        disk_->Write(begin, memcache, length);
+    }
+
+    void Truncate(uint64_t const new_size) override
+    {
+        TryFlushWriteCache();
+        disk_->Truncate(new_size);
+        file_size_ = new_size;
+    }
+
+    std::string GetFileName() override { return disk_->GetFileName(); }
+
+    void SetReadCache(uint8_t* buffer, uint64_t size)
+    {
+        read_buffer_ = buffer;
+        read_buffer_capacity_ = size;
+        read_buffer_start_ = -1;
+        read_buffer_size_ = 0;
+    }
+
+    void SetWriteCache(uint8_t* buffer, uint64_t size)
+    {
+        write_buffer_ = buffer;
+        write_buffer_capacity_ = size;
+        write_buffer_start_ = -1;
+        write_buffer_size_ = 0;
+    }
+
+private:
+
+    void TryFlushWriteCache()
+    {
+        if (write_buffer_size_ == 0) return;
+
+        disk_->Write(write_buffer_start_, write_buffer_, write_buffer_size_);
+        write_buffer_size_ = 0;
+    }
+
+    Disk* disk_;
+
+    uint64_t file_size_;
+
+    // the file offset the read buffer was read from
+    uint64_t read_buffer_start_ = -1;
+    uint8_t* read_buffer_ = nullptr;
+    uint64_t read_buffer_size_ = 0;
+    uint64_t read_buffer_capacity_ = 0;
+
+    // the file offset the write buffer should be written back to
+    // the write buffer is *only* for contiguous and sequential writes
+    uint64_t write_buffer_start_ = -1;
+    uint8_t* write_buffer_ = nullptr;
+    uint64_t write_buffer_size_ = 0;
+    uint64_t write_buffer_capacity_ = 0;
+};
+
 #endif  // SRC_CPP_DISK_HPP_

--- a/src/disk.hpp
+++ b/src/disk.hpp
@@ -39,6 +39,7 @@ namespace fs = ghc::filesystem;
 
 #include "./bits.hpp"
 #include "./util.hpp"
+#include "bitfield.hpp"
 
 constexpr uint64_t write_cache = 4 * 1024 * 1024;
 constexpr uint64_t read_ahead = 4 * 1024 * 1024;
@@ -336,6 +337,95 @@ private:
     uint64_t write_buffer_start_ = -1;
     std::unique_ptr<uint8_t[]> write_buffer_;
     uint64_t write_buffer_size_ = 0;
+};
+
+struct FilteredDisk : Disk
+{
+    FilteredDisk(BufferedDisk underlying, bitfield filter, int entry_size)
+        : filter_(std::move(filter))
+        , underlying_(std::move(underlying))
+        , entry_size_(entry_size)
+    {
+        assert(entry_size_ > 0);
+        while (!filter_.get(last_idx_)) {
+            last_physical_ += entry_size_;
+            ++last_idx_;
+        }
+        assert(filter_.get(last_idx_));
+        assert(last_physical_ == last_idx_ * entry_size_);
+    }
+
+    uint8_t const* Read(uint64_t begin, uint64_t length) override
+    {
+        // we only support a single read-pass with no going backwards
+        assert(begin >= last_logical_);
+        assert((begin % entry_size_) == 0);
+        assert(filter_.get(last_idx_));
+        assert(last_physical_ == last_idx_ * entry_size_);
+
+        if (begin > last_logical_) {
+            // last_idx_ et.al. always points to an entry we have (i.e. the bit
+            // is set). So when we advance from there, we always take at least
+            // one step on all counters.
+            last_logical_ += entry_size_;
+            last_physical_ += entry_size_;
+            ++last_idx_;
+
+            while (begin > last_logical_)
+            {
+                if (filter_.get(last_idx_)) {
+                    last_logical_ += entry_size_;
+                }
+                last_physical_ += entry_size_;
+                ++last_idx_;
+            }
+
+            while (!filter_.get(last_idx_)) {
+                last_physical_ += entry_size_;
+                ++last_idx_;
+            }
+        }
+
+        assert(filter_.get(last_idx_));
+        assert(last_physical_ == last_idx_ * entry_size_);
+        assert(begin == last_logical_);
+        return underlying_.Read(last_physical_, length);
+    }
+
+    void Write(uint64_t begin, const uint8_t *memcache, uint64_t length) override
+    {
+        assert(false);
+        throw std::runtime_error("Write() called on read-only disk abstraction");
+    }
+    void Truncate(uint64_t new_size) override
+    {
+        underlying_.Truncate(new_size);
+        if (new_size == 0) filter_.free_memory();
+    }
+    std::string GetFileName() override { return underlying_.GetFileName(); }
+    void FreeMemory() override
+    {
+        filter_.free_memory();
+        underlying_.FreeMemory();
+    }
+
+private:
+
+    // only entries whose bit is set should be read
+    bitfield filter_;
+    BufferedDisk underlying_;
+    int entry_size_;
+
+    // the "physical" disk offset of the last read
+    uint64_t last_physical_ = 0;
+    // the "logical" disk offset of the last read. i.e. the offset as if the
+    // file would have been compacted based on filter_
+    uint64_t last_logical_ = 0;
+
+    // the index of the last read. This is also the index into the bitfield. It
+    // could be computed as last_physical_ / entry_size_, but we want to avoid
+    // the division.
+    uint64_t last_idx_ = 0;
 };
 
 #endif  // SRC_CPP_DISK_HPP_

--- a/src/phase2.hpp
+++ b/src/phase2.hpp
@@ -18,6 +18,7 @@
 #include "disk.hpp"
 #include "entry_sizes.hpp"
 #include "sort_manager.hpp"
+#include "bitfield_index.hpp"
 
 // Backpropagate takes in as input, a file on which forward propagation has been done.
 // The purpose of backpropagate is to eliminate any dead entries that don't contribute
@@ -27,384 +28,263 @@ std::vector<uint64_t> RunPhase2(
     uint8_t *memory,
     std::vector<FileDisk> &tmp_1_disks,
     std::vector<uint64_t> table_sizes,
-    uint8_t k,
+    uint8_t const k,
     const uint8_t *id,
     const std::string &tmp_dirname,
     const std::string &filename,
-    uint64_t memory_size,
-    uint32_t num_buckets,
-    uint32_t log_num_buckets)
+    uint64_t const memory_size,
+    uint32_t const num_buckets,
+    uint32_t const log_num_buckets)
 {
     // An extra bit is used, since we may have more than 2^k entries in a table. (After pruning,
-    // each table will have 0.8*2^k or less entries).
-    uint8_t pos_size = k;
+    // each table will have 0.8*2^k or fewer entries).
+    uint8_t const pos_size = k;
 
-    std::vector<uint64_t> new_table_sizes = std::vector<uint64_t>(8, 0);
+    std::vector<uint64_t> new_table_sizes(8, 0);
     new_table_sizes[7] = table_sizes[7];
-    std::unique_ptr<SortManager> R_sort_manager;
-    std::unique_ptr<SortManager> L_sort_manager;
 
-    // Iterates through each table (with a left and right pointer), starting at 6 & 7.
+    // Iterates through each table, starting at 6 & 7. Each iteration, we scan
+    // the current table twice. In the first scan, we:
+
+    // 1. drop entries marked as false in the current bitfield (except table 7,
+    //    where we don't drop anything, this is a special case)
+    // 2. mark entries in the next_bitfield that non-dropped entries have
+    //    references to
+
+    // The second scan of the table, we update the positions and offsets to
+    // reflect the entries that will be dropped in the next table.
+
+    // At the end of the iteration, we transfer the next_bitfield to the current bitfield
+    // to use it to prune the next table to scan.
+
+    // TODO: use a custom class that interprets a flag buffer as a bitfield.
+    // We'll need optimized bit-operations (like popcnt) later. Make sure the
+    // memory is 64 bit aligned
+    std::vector<bool> next_bitfield;
+    std::vector<bool> current_bitfield;
+
+    // note that we don't iterate over table_index=1. That table is special
+    // since it contains different data. We'll do an extra scan of table 1 at
+    // the end, just to compact it.
     for (int table_index = 7; table_index > 1; --table_index) {
-        // std::vector<std::pair<uint64_t, uint64_t> > match_positions;
-        Timer table_timer;
 
         std::cout << "Backpropagating on table " << table_index << std::endl;
 
-        uint16_t left_metadata_size = kVectorLens[table_index] * k;
+        Timer scan_timer;
 
-        // The entry that we are reading (no metadata)
-        uint16_t left_entry_size_bytes = EntrySizes::GetMaxEntrySize(k, table_index - 1, false);
+        next_bitfield.clear();
+        next_bitfield.resize(table_sizes[table_index - 1], false);
 
-        // The right entries which we read and write (the already have no metadata, since they
-        // have been pruned in previous iteration)
-        uint16_t right_entry_size_bytes = EntrySizes::GetMaxEntrySize(k, table_index, false);
+        int64_t const table_size = table_sizes[table_index];
+        int16_t const entry_size = EntrySizes::GetMaxEntrySize(k, table_index, false);
 
-        uint64_t left_reader = 0;
-        uint64_t left_writer = 0;
-        uint64_t right_reader = 0;
-        uint64_t right_writer = 0;
-        // The memory will be used like this, with most memory allocated towards the SortManager,
-        // since it needs it
-        // [--------------------------SM/RR-------------------------|-----------LW-------------|--RW--|--LR--]
-        uint64_t sort_manager_buf_size = floor(kMemSortProportion * memory_size);
-        uint64_t left_writer_buf_size = 3 * (memory_size - sort_manager_buf_size) / 4;
-        uint64_t other_buf_sizes = (memory_size - sort_manager_buf_size - left_writer_buf_size) / 2;
-        uint8_t *right_reader_buf = &(memory[0]);
-        uint8_t *left_writer_buf = &(memory[sort_manager_buf_size]);
-        uint8_t *right_writer_buf = &(memory[sort_manager_buf_size + left_writer_buf_size]);
-        uint8_t *left_reader_buf =
-            &(memory[sort_manager_buf_size + left_writer_buf_size + other_buf_sizes]);
-        uint64_t right_reader_buf_entries = sort_manager_buf_size / right_entry_size_bytes;
-        uint64_t left_writer_buf_entries = left_writer_buf_size / left_entry_size_bytes;
-        uint64_t right_writer_buf_entries = other_buf_sizes / right_entry_size_bytes;
-        uint64_t left_reader_buf_entries = other_buf_sizes / left_entry_size_bytes;
-        uint64_t left_reader_count = 0;
-        uint64_t right_reader_count = 0;
-        uint64_t left_writer_count = 0;
-        uint64_t right_writer_count = 0;
+        uint8_t* read_buffer = memory;
+        int64_t const read_buffer_size = (memory_size / 2) - (memory_size / 2) % entry_size;
+        // the number of entries we've processed so far (in the current table)
+        // i.e. the index to the current entry. This is not used for table 7
+        int64_t read_index = 0;
 
-        if (table_index != 7) {
-            R_sort_manager->ChangeMemory(memory, sort_manager_buf_size);
-        }
+        int64_t read_cursor = 0;
+        while (read_index < table_size)
+        {
+            // instead of reading a single entry at a time, cache
+            // read_buffer_size bytes worth of entries
+            int64_t const to_read = std::min(read_buffer_size, table_size * entry_size - read_cursor);
 
-        L_sort_manager = std::make_unique<SortManager>(
-            left_writer_buf,
-            left_writer_buf_size,
-            num_buckets,
-            log_num_buckets,
-            left_entry_size_bytes,
-            tmp_dirname,
-            filename + ".p2.t" + std::to_string(table_index - 1),
-            0,
-            0);
+            tmp_1_disks[table_index].Read(
+                read_cursor, read_buffer, to_read);
+            read_cursor += to_read;
 
-        // We will divide by 2, so it must be even.
-        assert(kCachedPositionsSize % 2 == 0);
-
-        // Used positions will be used to mark which posL are present in table R, the rest will
-        // be pruned
-        bool used_positions[kCachedPositionsSize];
-        memset(used_positions, 0, sizeof(used_positions));
-
-        bool should_read_entry = true;
-
-        // Cache for when we read a right entry that is too far forward
-        uint64_t cached_entry_sort_key = 0;  // For table_index == 7, y is here
-        uint64_t cached_entry_pos = 0;
-        uint64_t cached_entry_offset = 0;
-
-        uint64_t left_entry_counter = 0;  // Total left entries written
-
-        // Sliding window map, from old position to new position (after pruning)
-        uint64_t new_positions[kCachedPositionsSize];
-
-        // Sort keys represent the ordering of entries, sorted by (y, pos, offset),
-        // but using less bits (only k+1 instead of 2k + 9, etc.)
-        // This is a map from old position to array of sort keys (one for each R entry with this
-        // pos)
-        uint64_t old_sort_keys[kReadMinusWrite][kMaxMatchesSingleEntry];
-        // Map from old position to other positions that it matches with
-        uint64_t old_offsets[kReadMinusWrite][kMaxMatchesSingleEntry];
-        // Map from old position to count (number of times it appears)
-        uint16_t old_counters[kReadMinusWrite];
-
-        for (uint16_t &old_counter : old_counters) {
-            old_counter = 0;
-        }
-
-        bool end_of_right_table = false;
-        uint64_t current_pos = 0;  // This is the current pos that we are looking for in the L table
-        uint64_t end_of_table_pos = 0;
-        uint64_t greatest_pos = 0;  // This is the greatest position we have seen in R table
-
-        // Buffers for reading and writing to disk
-        uint8_t *left_entry_buf;
-        uint8_t *new_left_entry_buf;
-        uint8_t *right_entry_buf;
-        uint8_t *right_entry_buf_SM = new uint8_t[right_entry_size_bytes];
-
-        // Go through all right entries, and keep going since write pointer is behind read
-        // pointer
-        while (!end_of_right_table || (current_pos - end_of_table_pos <= kReadMinusWrite)) {
-            old_counters[current_pos % kReadMinusWrite] = 0;
-
-            // Resets used positions after a while, so we use little memory
-            if ((current_pos - kReadMinusWrite) % (kCachedPositionsSize / 2) == 0) {
-                if ((current_pos - kReadMinusWrite) % kCachedPositionsSize == 0) {
-                    for (uint32_t i = kCachedPositionsSize / 2; i < kCachedPositionsSize; i++) {
-                        used_positions[i] = false;
-                    }
-                } else {
-                    for (uint32_t i = 0; i < kCachedPositionsSize / 2; i++) {
-                        used_positions[i] = false;
-                    }
-                }
-            }
-            // Only runs this code if we are still reading the right table, or we still need to
-            // read more left table entries (current_pos <= greatest_pos), otherwise, it skips
-            // to the writing of the final R table entries
-            if (!end_of_right_table || current_pos <= greatest_pos) {
-                uint64_t entry_sort_key = 0;
+            // iterate over the cached entries
+            for (uint8_t const* i = read_buffer;
+                i < read_buffer + to_read;
+                i += entry_size, ++read_index)
+            {
                 uint64_t entry_pos = 0;
                 uint64_t entry_offset = 0;
-
-                while (!end_of_right_table) {
-                    if (should_read_entry) {
-                        if (right_reader_count == new_table_sizes[table_index]) {
-                            // Table R has ended, don't read any more (but keep writing)
-                            end_of_right_table = true;
-                            end_of_table_pos = current_pos;
-                            break;
-                        }
-                        // Need to read another entry at the current position
-                        if (table_index == 7) {
-                            if (right_reader_count % right_reader_buf_entries == 0) {
-                                uint64_t readAmt = std::min(
-                                    right_reader_buf_entries * right_entry_size_bytes,
-                                    (new_table_sizes[table_index] - right_reader_count) *
-                                        right_entry_size_bytes);
-
-                                tmp_1_disks[table_index].Read(
-                                    right_reader, right_reader_buf, readAmt);
-                                right_reader += readAmt;
-                            }
-                            right_entry_buf =
-                                right_reader_buf + (right_reader_count % right_reader_buf_entries) *
-                                                       right_entry_size_bytes;
-                        } else {
-                            right_entry_buf = R_sort_manager->ReadEntry(right_reader);
-                            right_reader += right_entry_size_bytes;
-                        }
-                        right_reader_count++;
-
-                        if (table_index == 7) {
-                            // This is actually y for table 7
-                            entry_sort_key = Util::SliceInt64FromBytes(right_entry_buf, 0, k);
-                            entry_pos = Util::SliceInt64FromBytes(right_entry_buf, k, pos_size);
-                            entry_offset = Util::SliceInt64FromBytes(
-                                right_entry_buf, k + pos_size, kOffsetSize);
-                        } else {
-                            entry_pos = Util::SliceInt64FromBytes(right_entry_buf, 0, pos_size);
-                            entry_offset =
-                                Util::SliceInt64FromBytes(right_entry_buf, pos_size, kOffsetSize);
-                            entry_sort_key = Util::SliceInt64FromBytes(
-                                right_entry_buf, pos_size + kOffsetSize, k + 1);
-                        }
-                    } else if (cached_entry_pos == current_pos) {
-                        // We have a cached entry at this position
-                        entry_sort_key = cached_entry_sort_key;
-                        entry_pos = cached_entry_pos;
-                        entry_offset = cached_entry_offset;
-                    } else {
-                        // The cached entry is at a later pos, so we don't read any more R
-                        // entries, read more L entries instead.
-                        break;
+                if (table_index == 7) {
+                    // table 7 is special, we never drop anything, so just build
+                    // next_bitfield
+                    entry_pos = Util::SliceInt64FromBytes(i, k, pos_size);
+                    entry_offset = Util::SliceInt64FromBytes(i, k + pos_size, kOffsetSize);
+                } else {
+                    if (!current_bitfield[read_index])
+                    {
+                        // This entry should be dropped.
+                        continue;
                     }
-
-                    should_read_entry = true;  // By default, read another entry
-                    if (entry_pos + entry_offset > greatest_pos) {
-                        // Greatest L pos that we should look for
-                        greatest_pos = entry_pos + entry_offset;
-                    }
-
-                    if (entry_pos == current_pos) {
-                        // The current L position is the current R entry
-                        // Marks the two matching entries as used (pos and pos+offset)
-                        used_positions[entry_pos % kCachedPositionsSize] = true;
-                        used_positions[(entry_pos + entry_offset) % kCachedPositionsSize] = true;
-
-                        uint64_t old_write_pos = entry_pos % kReadMinusWrite;
-
-                        // Stores the sort key for this R entry
-                        old_sort_keys[old_write_pos][old_counters[old_write_pos]] = entry_sort_key;
-
-                        // Stores the other matching pos for this R entry (pos6 + offset)
-                        old_offsets[old_write_pos][old_counters[old_write_pos]] =
-                            entry_pos + entry_offset;
-                        ++old_counters[old_write_pos];
-                    } else {
-                        // Don't read any more right entries for now, because we haven't caught
-                        // up on the left table yet
-                        should_read_entry = false;
-                        cached_entry_sort_key = entry_sort_key;
-                        cached_entry_pos = entry_pos;
-                        cached_entry_offset = entry_offset;
-                        break;
-                    }
+                    entry_pos = Util::SliceInt64FromBytes(i, 0, pos_size);
+                    entry_offset = Util::SliceInt64FromBytes(i, pos_size, kOffsetSize);
                 }
-                // ***Reads a left entry
-                if (left_reader_count % left_reader_buf_entries == 0) {
-                    uint64_t readAmt = std::min(
-                        left_reader_buf_entries * left_entry_size_bytes,
-                        (table_sizes[table_index - 1] - left_reader_count) * left_entry_size_bytes);
-                    tmp_1_disks[table_index - 1].Read(left_reader, left_reader_buf, readAmt);
-                    left_reader += readAmt;
-                }
-                left_entry_buf = left_reader_buf + (left_reader_count % left_reader_buf_entries) *
-                                                       left_entry_size_bytes;
-                left_reader_count++;
 
-                // If this left entry is used, we rewrite it. If it's not used, we ignore it.
-                if (used_positions[current_pos % kCachedPositionsSize]) {
-                    uint64_t entry_metadata;
-
-                    if (table_index > 2) {
-                        // For tables 2-6, the entry is: pos, offset
-                        entry_pos = Util::SliceInt64FromBytes(left_entry_buf, 0, pos_size);
-                        entry_offset =
-                            Util::SliceInt64FromBytes(left_entry_buf, pos_size, kOffsetSize);
-                    } else {
-                        entry_metadata =
-                            Util::SliceInt64FromBytes(left_entry_buf, 0, left_metadata_size);
-                    }
-
-                    new_left_entry_buf =
-                        left_writer_buf +
-                        (left_writer_count % left_writer_buf_entries) * left_entry_size_bytes;
-                    left_writer_count++;
-
-                    Bits new_left_entry;
-                    if (table_index > 2) {
-                        // The new left entry is slightly different. Metadata is dropped, to
-                        // save space, and the counter of the entry is written (sort_key). We
-                        // use this instead of (y + pos + offset) since its smaller.
-                        new_left_entry += Bits(entry_pos, pos_size);
-                        new_left_entry += Bits(entry_offset, kOffsetSize);
-                        new_left_entry += Bits(left_entry_counter, k + 1);
-
-                        // If we are not taking up all the bits, make sure they are zeroed
-                        if (Util::ByteAlign(new_left_entry.GetSize()) < left_entry_size_bytes * 8) {
-                            new_left_entry +=
-                                Bits(0, left_entry_size_bytes * 8 - new_left_entry.GetSize());
-                        }
-                        L_sort_manager->AddToCache(new_left_entry);
-                    } else {
-                        // For table one entries, we don't care about sort key, only x.
-                        // Also, we don't use the sort manager, since we won't sort it.
-                        new_left_entry += Bits(entry_metadata, left_metadata_size);
-                        new_left_entry.ToBytes(new_left_entry_buf);
-                        if (left_writer_count % left_writer_buf_entries == 0) {
-                            tmp_1_disks[table_index - 1].Write(
-                                left_writer,
-                                left_writer_buf,
-                                left_writer_buf_entries * left_entry_size_bytes);
-                            left_writer += left_writer_buf_entries * left_entry_size_bytes;
-                        }
-                    }
-
-                    // Mapped positions, so we can rewrite the R entry properly
-                    new_positions[current_pos % kCachedPositionsSize] = left_entry_counter;
-
-                    // Counter for new left entries written
-                    ++left_entry_counter;
-                }
+                // mark the two matching entries as used (pos and pos+offset)
+                next_bitfield[entry_pos] = true;
+                next_bitfield[entry_pos + entry_offset] = true;
             }
-            // Write pointer lags behind the read pointer
-            int64_t write_pointer_pos = current_pos - kReadMinusWrite + 1;
-
-            // Only write entries for write_pointer_pos, if we are above 0, and there are
-            // actually R entries for that pos.
-            if (write_pointer_pos >= 0 &&
-                used_positions[write_pointer_pos % kCachedPositionsSize]) {
-                uint64_t new_pos = new_positions[write_pointer_pos % kCachedPositionsSize];
-                Bits new_pos_bin(new_pos, pos_size);
-                // There may be multiple R entries that share the write_pointer_pos, so write
-                // all of them
-                for (uint32_t counter = 0;
-                     counter < old_counters[write_pointer_pos % kReadMinusWrite];
-                     counter++) {
-                    // Creates and writes the new right entry, with the cached data
-                    uint64_t new_offset_pos = new_positions
-                        [old_offsets[write_pointer_pos % kReadMinusWrite][counter] %
-                         kCachedPositionsSize];
-                    Bits new_right_entry =
-                        table_index == 7
-                            ? Bits(old_sort_keys[write_pointer_pos % kReadMinusWrite][counter], k)
-                            : Bits(
-                                  old_sort_keys[write_pointer_pos % kReadMinusWrite][counter],
-                                  k + 1);
-                    new_right_entry += new_pos_bin;
-                    // match_positions.push_back(std::make_pair(new_pos, new_offset_pos));
-                    new_right_entry.AppendValue(new_offset_pos - new_pos, kOffsetSize);
-
-                    // Calculate right entry pointer for output
-                    right_entry_buf =
-                        right_writer_buf +
-                        (right_writer_count % right_writer_buf_entries) * right_entry_size_bytes;
-                    right_writer_count++;
-
-                    if (Util::ByteAlign(new_right_entry.GetSize()) < right_entry_size_bytes * 8) {
-                        memset(right_entry_buf, 0, right_entry_size_bytes);
-                    }
-                    new_right_entry.ToBytes(right_entry_buf);
-                    // Check for write out to disk
-                    if (right_writer_count % right_writer_buf_entries == 0) {
-                        tmp_1_disks[table_index].Write(
-                            right_writer,
-                            right_writer_buf,
-                            right_writer_buf_entries * right_entry_size_bytes);
-                        right_writer += right_writer_buf_entries * right_entry_size_bytes;
-                    }
-                }
-            }
-            ++current_pos;
         }
-        new_table_sizes[table_index - 1] = left_entry_counter;
 
-        std::cout << "\tWrote left entries: " << left_entry_counter << std::endl;
-        table_timer.PrintElapsed("Total backpropagation time::");
+        std::cout << "scanned table " << table_index << std::endl;
+        scan_timer.PrintElapsed("scanned time = ");
 
-        tmp_1_disks[table_index].Write(
-            right_writer,
-            right_writer_buf,
-            (right_writer_count % right_writer_buf_entries) * right_entry_size_bytes);
-        right_writer += (right_writer_count % right_writer_buf_entries) * right_entry_size_bytes;
+        std::cout << "sorting table " << table_index << std::endl;
+        Timer sort_timer;
+
+        // read the same table again. This time we'll output it to new files:
+        // * add sort_key (just the index of the current entry)
+        // * update (pos, offset) to remain valid after table_index-1 has been
+        //   compacted.
+        // * sort by pos
+
+        uint8_t* sort_cache = memory + read_buffer_size;
+        uint64_t const sort_cache_size = memory_size - read_buffer_size;
+        auto sort_manager = std::make_unique<SortManager>(
+            sort_cache,
+            sort_cache_size,
+            num_buckets,
+            log_num_buckets,
+            uint16_t(entry_size),
+            tmp_dirname,
+            filename + ".p2.t" + std::to_string(table_index),
+            uint32_t(k + 1),
+            0,
+            strategy_t::quicksort);
+
+        // as we scan the table for the second time, we'll also need to remap
+        // the positions and offsets based on the next_bitfield.
+        bitfield_index const index(next_bitfield);
+
+        read_index = 0;
+        read_cursor = 0;
+        int64_t write_counter = 0;
+        while (read_index < table_size)
+        {
+            // instead of reading a single entry at a time, cache
+            // read_buffer_size bytes worth of entries
+            int64_t const to_read = std::min(read_buffer_size, table_size * entry_size - read_cursor);
+
+            tmp_1_disks[table_index].Read(
+                read_cursor, read_buffer, to_read);
+            read_cursor += to_read;
+
+            // iterate over the cached entries
+            for (uint8_t* i = read_buffer;
+                i < read_buffer + to_read;
+                i += entry_size, ++read_index)
+            {
+                uint64_t entry_pos = 0;
+                uint64_t entry_offset = 0;
+                uint64_t entry_f7 = 0;
+                if (table_index == 7) {
+                    // table 7 is special, we never drop anything, so just build
+                    // next_bitfield
+                    entry_f7 = Util::SliceInt64FromBytes(i, 0, k);
+                    entry_pos = Util::SliceInt64FromBytes(i, k, pos_size);
+                    entry_offset = Util::SliceInt64FromBytes(i, k + pos_size, kOffsetSize);
+                } else {
+                    // skipping
+                    if (!current_bitfield[read_index]) continue;
+
+                    entry_pos = Util::SliceInt64FromBytes(i, 0, pos_size);
+                    entry_offset = Util::SliceInt64FromBytes(i, pos_size, kOffsetSize);
+                }
+
+                // assemble the new entry and write it to the sort manager
+
+                // map the pos and offset to the new, compacted, positions and
+                // offsets
+                std::tie(entry_pos, entry_offset) = index.lookup(entry_pos, entry_offset);
+
+                if (table_index == 7) {
+                    // table 7 is already sorted by pos, so we just rewrite the
+                    // pos and offset in-place
+
+                    Bits new_entry;
+                    new_entry += Bits(entry_f7, k);
+                    new_entry += Bits(entry_pos, pos_size);
+                    new_entry += Bits(entry_offset, kOffsetSize);
+
+                    new_entry.ToBytes(i);
+                    tmp_1_disks[table_index].Write(read_index * entry_size, i, entry_size);
+                }
+                else {
+                    Bits new_entry;
+                    // The new entry is slightly different. Metadata is dropped, to
+                    // save space, and the counter of the entry is written (sort_key). We
+                    // use this instead of (y + pos + offset) since its smaller.
+                    new_entry += Bits(write_counter, k + 1);
+                    new_entry += Bits(entry_pos, pos_size);
+                    new_entry += Bits(entry_offset, kOffsetSize);
+
+                    assert(new_entry.GetSize() <= uint32_t(entry_size) * 8);
+
+                    // If we are not taking up all the bits, make sure they are zeroed
+                    if (Util::ByteAlign(new_entry.GetSize()) < uint32_t(entry_size) * 8) {
+                        new_entry +=
+                            Bits(0, entry_size * 8 - new_entry.GetSize());
+                    }
+
+                    sort_manager->AddToCache(new_entry);
+                }
+                ++write_counter;
+            }
+        }
 
         if (table_index != 7) {
-            R_sort_manager.reset();
+            sort_manager->FlushCache();
+            sort_timer.PrintElapsed("sort time = ");
+
+            std::cout << "writing sorted table " << table_index << std::endl;
+            Timer render_timer;
+
+            for (int64_t i = 0; i < write_counter; ++i) {
+
+                uint8_t const* entry = sort_manager->ReadEntry(i * entry_size);
+                tmp_1_disks[table_index].Write(i * entry_size, entry, entry_size);
+            }
+
+            tmp_1_disks[table_index].Truncate(write_counter * entry_size);
+            new_table_sizes[table_index] = write_counter;
+            std::cout << "table " << table_index << " new size: " << new_table_sizes[table_index] << std::endl;
+
+            render_timer.PrintElapsed("render phase 2 table: ");
         }
-
-        // Truncates the right table
-        tmp_1_disks[table_index].Truncate(right_writer);
-
-        if (table_index == 2) {
-            // Writes remaining entries for table1
-            tmp_1_disks[table_index - 1].Write(
-                left_writer,
-                left_writer_buf,
-                (left_writer_count % left_writer_buf_entries) * left_entry_size_bytes);
-            left_writer += (left_writer_count % left_writer_buf_entries) * left_entry_size_bytes;
-
-            // Truncates the left table
-            tmp_1_disks[table_index - 1].Truncate(left_writer);
-        } else {
-            L_sort_manager->FlushCache();
-            R_sort_manager = std::move(L_sort_manager);
-        }
-        delete[] right_entry_buf_SM;
+        current_bitfield = std::move(next_bitfield);
+        next_bitfield.clear();
     }
-    L_sort_manager.reset();
+
+    // compact table 1 based on current_bitfield
+
+    int const table_index = 1;
+    int64_t const table_size = table_sizes[table_index];
+    int16_t const entry_size = EntrySizes::GetMaxEntrySize(k, table_index, false);
+    int64_t read_cursor = 0;
+    int64_t write_counter = 0;
+    int64_t write_cursor = 0;
+    uint8_t* entry = memory;
+
+    std::cout << "compacting table " << table_index << std::endl;
+
+    for (int64_t read_counter = 0; read_counter < table_size; ++read_counter, read_cursor += entry_size) {
+
+        if (current_bitfield[read_counter] == false)
+            continue;
+
+        tmp_1_disks[table_index].Read(read_cursor, entry, entry_size);
+
+        // in the beginning of the table, there may be a few entries that
+        // haven't moved, no need to write the same bytes back again
+        if (write_cursor != read_cursor) {
+            tmp_1_disks[table_index].Write(write_cursor, entry, entry_size);
+        }
+        ++write_counter;
+        write_cursor += entry_size;
+    }
+
+    tmp_1_disks[table_index].Truncate(write_cursor);
+    new_table_sizes[table_index] = write_counter;
+
+    std::cout << "table " << table_index << " new size: " << new_table_sizes[table_index] << std::endl;
+
     return new_table_sizes;
 }
 

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -189,7 +189,7 @@ Phase3Results RunPhase3(
         }
 
         R_sort_manager = std::make_unique<SortManager>(
-            memory_size / 2,
+            (table_index == 1 || table_index == 6) ? memory_size : (memory_size / 2),
             num_buckets,
             log_num_buckets,
             right_entry_size_bytes,
@@ -365,7 +365,7 @@ Phase3Results RunPhase3(
         // reader
         R_sort_manager->FreeMemory();
         L_sort_manager = std::make_unique<SortManager>(
-            memory_size / 2,
+            (table_index == 6) ? memory_size : (memory_size / 2),
             num_buckets,
             log_num_buckets,
             right_entry_size_bytes,

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -228,7 +228,7 @@ public:
                       << Timer::GetNow();
 
             Timer p2;
-            std::vector<uint64_t> backprop_table_sizes = RunPhase2(
+            Phase2Results res2 = RunPhase2(
                 memory.get(),
                 tmp_1_disks,
                 table_sizes,
@@ -252,8 +252,7 @@ public:
                 memory.get(),
                 k,
                 tmp2_disk,
-                tmp_1_disks,
-                backprop_table_sizes,
+                res2,
                 id,
                 tmp_dirname,
                 filename,

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -223,12 +223,8 @@ public:
                       << "Starting phase 2/4: Backpropagation into tmp files... "
                       << Timer::GetNow();
 
-            // Memory to be used for sorting and buffers
-            std::unique_ptr<uint8_t[]> memory(new uint8_t[memory_size + 7]);
-
             Timer p2;
             Phase2Results res2 = RunPhase2(
-                memory.get(),
                 tmp_1_disks,
                 table_sizes,
                 k,
@@ -239,8 +235,6 @@ public:
                 num_buckets,
                 log_num_buckets);
             p2.PrintElapsed("Time for phase 2 =");
-
-            memory.reset();
 
             // Now we open a new file, where the final contents of the plot will be stored.
             uint32_t header_size = WriteHeader(tmp2_disk, k, id, memo, memo_len);

--- a/src/uniformsort.hpp
+++ b/src/uniformsort.hpp
@@ -33,7 +33,7 @@
 class UniformSort {
 public:
     inline static void SortToMemory(
-        Disk &input_disk,
+        FileDisk &input_disk,
         uint64_t input_disk_begin,
         uint8_t *memory,
         uint32_t entry_len,

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -698,8 +698,7 @@ TEST_CASE("Sort on disk")
         uint32_t size = 32;
         vector<Bits> input;
         const uint32_t memory_len = 1000000;
-        uint8_t* memory = new uint8_t[memory_len];
-        SortManager manager(memory, memory_len, 16, 4, size, ".", "test-files", 0, 1);
+        SortManager manager(memory_len, 16, 4, size, ".", "test-files", 0, 1);
         int total_written_1 = 0;
         for (uint32_t i = 0; i < iters; i++) {
             vector<unsigned char> hash_input = intToBytes(i, 4);
@@ -719,7 +718,6 @@ TEST_CASE("Sort on disk")
             input[i].ToBytes(buf);
             REQUIRE(memcmp(buf, buf3, size) == 0);
         }
-        delete[] memory;
     }
 
     SECTION("Lazy Sort Manager uniform sort")
@@ -728,8 +726,7 @@ TEST_CASE("Sort on disk")
         uint32_t size = 32;
         vector<Bits> input;
         const uint32_t memory_len = 1000000;
-        uint8_t* memory = new uint8_t[memory_len];
-        SortManager manager(memory, memory_len, 16, 4, size, ".", "test-files", 0, 1);
+        SortManager manager(memory_len, 16, 4, size, ".", "test-files", 0, 1);
         int total_written_1 = 0;
         for (uint32_t i = 0; i < iters; i++) {
             vector<unsigned char> hash_input = intToBytes(i, 4);
@@ -749,7 +746,6 @@ TEST_CASE("Sort on disk")
             input[i].ToBytes(buf);
             REQUIRE(memcmp(buf, buf3, size) == 0);
         }
-        delete[] memory;
     }
 
     SECTION("Sort in Memory")

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -782,8 +782,7 @@ TEST_CASE("Sort on disk")
 
 TEST_CASE("bitfield-simple")
 {
-    uint64_t buffer[1];
-    bitfield b(reinterpret_cast<uint8_t*>(buffer), sizeof(buffer));
+    bitfield b(4);
     CHECK(!b.get(0));
     CHECK(!b.get(1));
     CHECK(!b.get(2));
@@ -810,8 +809,7 @@ TEST_CASE("bitfield-simple")
 
 TEST_CASE("bitfield-count")
 {
-    uint64_t buffer[8];
-    bitfield b(reinterpret_cast<uint8_t*>(buffer), sizeof(buffer));
+    bitfield b(512);
 
     for (int i = 0; i < 512; ++i) {
         CHECK(b.count(0, 512) == i);
@@ -824,8 +822,7 @@ TEST_CASE("bitfield-count")
 
 TEST_CASE("bitfield-count-unaligned")
 {
-    uint64_t buffer[8];
-    bitfield b(reinterpret_cast<uint8_t*>(buffer), sizeof(buffer));
+    bitfield b(512);
 
     for (int i = 0; i < 512; ++i) {
         b.set(i);
@@ -838,8 +835,7 @@ TEST_CASE("bitfield-count-unaligned")
 
 TEST_CASE("bitfield_index-simple")
 {
-    uint64_t buffer[1];
-    bitfield b(reinterpret_cast<uint8_t*>(buffer), sizeof(buffer));
+    bitfield b(64);
     b.set(0);
     b.set(1);
     b.set(3);
@@ -856,8 +852,7 @@ TEST_CASE("bitfield_index-simple")
 
 TEST_CASE("bitfield_index-use index")
 {
-    uint64_t buffer[1048576 / 64];
-    bitfield b(reinterpret_cast<uint8_t*>(buffer), sizeof(buffer));
+    bitfield b(1048576);
     CHECK(b.size() == 1048576);
     b.set(1048576 - 3);
     b.set(1048576 - 2);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -861,3 +861,45 @@ TEST_CASE("bitfield_index-use index")
     CHECK(idx.lookup(1048576 - 3, 1) == std::pair<uint64_t, uint64_t>{0,1});
     CHECK(idx.lookup(1048576 - 2, 1) == std::pair<uint64_t, uint64_t>{1,1});
 }
+
+TEST_CASE("bitfield_index edge-cases")
+{
+    bitfield b(1048576);
+    CHECK(b.size() == 1048576);
+    b.set(0);
+    b.set(bitfield_index::kIndexBucket);
+    b.set(bitfield_index::kIndexBucket * 2);
+    b.set(1048576 - 1);
+    bitfield_index const idx(b);
+    CHECK(idx.lookup(0, 0) == std::pair<uint64_t, uint64_t>{0,0});
+    CHECK(idx.lookup(0, bitfield_index::kIndexBucket) == std::pair<uint64_t, uint64_t>{0,1});
+    CHECK(idx.lookup(0, bitfield_index::kIndexBucket * 2) == std::pair<uint64_t, uint64_t>{0,2});
+    CHECK(idx.lookup(0, 1048576 - 1) == std::pair<uint64_t, uint64_t>{0,3});
+
+    CHECK(idx.lookup(bitfield_index::kIndexBucket, 0) == std::pair<uint64_t, uint64_t>{1,0});
+    CHECK(idx.lookup(bitfield_index::kIndexBucket, bitfield_index::kIndexBucket) == std::pair<uint64_t, uint64_t>{1,1});
+    CHECK(idx.lookup(bitfield_index::kIndexBucket, 1048576 - 1 - bitfield_index::kIndexBucket)
+		== std::pair<uint64_t, uint64_t>{1,2});
+
+	CHECK(idx.lookup(bitfield_index::kIndexBucket * 2, 1048576 - 1 - bitfield_index::kIndexBucket * 2)
+		== std::pair<uint64_t, uint64_t>{2,1});
+    CHECK(idx.lookup(1048576 - 1, 0) == std::pair<uint64_t, uint64_t>{3,0});
+}
+
+void test_bitfield_size(int const size)
+{
+    bitfield b(size);
+    b.set(0);
+    b.set(size - 1);
+    bitfield_index const idx(b);
+    CHECK(idx.lookup(0, 0) == std::pair<uint64_t, uint64_t>{0,0});
+    CHECK(idx.lookup(0, size - 1) == std::pair<uint64_t, uint64_t>{0,1});
+    CHECK(idx.lookup(size - 1, 0) == std::pair<uint64_t, uint64_t>{1,0});
+}
+
+TEST_CASE("bitfield_index edge-sizes")
+{
+	test_bitfield_size(bitfield_index::kIndexBucket - 1);
+	test_bitfield_size(bitfield_index::kIndexBucket);
+	test_bitfield_size(bitfield_index::kIndexBucket + 1);
+}


### PR DESCRIPTION
This avoids some sort-on-disk in phase2 (back-propagation) by recording which entries in `table_index` are used by `table_index + 1`. Phase 2 now looks like this:

* loop from table 7..1:
  * scan current table:
    * if table < 7, skip any entries not set in `current_bitfield`
    * record the indices we find in the the current table by setting the corresponding bit in `previous_bitfield`
  * if table < 7: scan current table (again):
    * compact table by skipping fields whose bit is not set in `current_bitfield`
    * write back each pos and offset with an adjusted position, based on the new (compacted) locations in `previous_bitfield`.
  * `current_bitfield` = `previous_bitfield`
  * clear all bits in `previous_bitfield`

In order to hand over the tables in the correct order, sorted as the current phase 2 does, the "write-back" step is really done into a `SortManager` object. This object is then passed on to phase 3, as if it was a `Disk`.

Enabling a `SortManager` to implement the Disk interface required a few changes. The `Disk` interface now returns a pointer to the entry, when reading from it. This is how `SortManager` returns data, and I envision it is how we will actually return data if we transition to memory mapped files too.

To allow passing a `SortManager` from one phase to the next, they now heap allocate their memory, rather than relying in being passed a buffer that is later reused.

Another optimization of the algorithm described above is that the last table, table 1, isn't sorted, it *just* need to be compacted. Instead of running a read and write-back pass over table 1, there's yet another abstraction implementing the `Disk` interface; `FilteredDisk`. It wraps a normal file along with a bitfield and provides an object that appears to be a compacted file. i.e. all the entries *not* set in the bitfield are skipped when reading from the file. This saves another read and write pass over table 1.

The last change that was necessary to unify the interfaces of `SortManager` and `Disk` was to provide a `BufferedDisk`. It wraps a plain file on disk but implements a read and write cache. This simplifies the loops in phase 2 and phase 3, where they no longer need to do their own read caching. Similarly, the `SortManager` no longer needs to do its own write caching when writing to buckets.

The intention of this patch is to reduce disk I/O. Enabling disk I/O logging and testing:

```
./ProofOfSpace create -k 24 -s 8192
```

Yields this result:

```
total-read:        5863072979
total-write:       5307037029
```

This can be compared to the current `master` I/O, with the same command:

```
total-read:        5713090499
total-write:       6035790148
```

That's a reduction of writes by 12,07% and an increase of reads by 2.63%.

When the full working set fits in RAM (i.e. no actual disk I/O is performed) this patch runs slower. This is most likely because the sorting of the buckets in phase3 is done twice, since phase 3 performs two read passes over the tables. It's expected that it will be faster when running against an a disk, plotting a file much larger than available RAM.