### PR TITLE
Don't pass empty string to msvc linker. Ref pypa/setuptools#2417.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class BuildExt(build_ext):
         "unix": [""],
     }
     l_opts = {
-        "msvc": [""],
+        "msvc": [],
         "unix": [""],
     }
 


### PR DESCRIPTION
Stop passing an empty string to the msvc linker with thanks to @jaraco