### PR TITLE
@jaraco @hoffmang9 Don't pass empty string to msvc linker. Ref pypa/setuptools#2417

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -84,7 +84,7 @@ jobs:
         CIBW_BEFORE_BUILD_MACOS: >
           python -m pip install --upgrade pip
         CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.14
-        CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_USE_DISTUTILS=stdlib
+        # CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_USE_DISTUTILS=stdlib
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: py.test -v {project}/tests -s
 

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ class BuildExt(build_ext):
     if sys.platform == "darwin":
         darwin_opts = ["-stdlib=libc++", "-mmacosx-version-min=10.14"]
         c_opts["unix"] += darwin_opts
-        l_opts["unix"] += darwin_opts
+        l_opts["unix"] += darwin_opts  # type: ignore
 
     def build_extensions(self):
         ct = self.compiler.compiler_type

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ class BuildExt(build_ext):
         "unix": [""],
     }
     l_opts = {
-        "msvc": [""],
+        "msvc": [],
         "unix": [""],
     }
 


### PR DESCRIPTION
Also removed SETUPTOOLS_USE_DISTUTILS=stdlib from the Windows environment