### PR TITLE
clear input files for tables

### DIFF
--- a/src/phase2.hpp
+++ b/src/phase2.hpp
@@ -235,6 +235,16 @@ Phase2Results RunPhase2(
         }
         current_bitfield.swap(next_bitfield);
         next_bitfield.clear();
+
+        // The files for Table 1 and 7 are re-used, overwritten and passed on to
+        // the next phase. However, table 2 through 6 are all written to sort
+        // managers that are passed on to the next phase. At this point, we have
+        // to delete the input files for table 2-6 to save disk space.
+        // This loop doesn't cover table 1, it's handled below with the
+        // FilteredDisk wrapper.
+        if (table_index != 7) {
+            tmp_1_disks[table_index].Truncate(0);
+        }
     }
 
     // lazy-compact table 1 based on current_bitfield


### PR DESCRIPTION
once they have been transformed into the that will be used in the next phase. This saves disk space.

My measurements of peak disk usage are (for a k24 plot):

```
current master: 1602MB
this patch: 964MB
prior to bitfield-patch: 1054MB
```

(these aren't exact, it's based on polling `ls -la` every 2 seconds during the plot)

There's still an issue that we leave *empty* files lingering longer than it seems necessary, but it's mostly a cosmetic issue.