### PR TITLE
reset read/write cursor on file close

### DIFF
--- a/src/disk.hpp
+++ b/src/disk.hpp
@@ -132,6 +132,8 @@ struct FileDisk {
         if (f_ == nullptr) return;
         ::fclose(f_);
         f_ = nullptr;
+        readPos = 0;
+        writePos = 0;
     }
 
     ~FileDisk() { Close(); }


### PR DESCRIPTION
when closing a file, the file's read and write cursor no longer exists, reset our prediction of it (this affects whether we call seek() or not before reading and writing)