### PR TITLE
Fix usort

### DIFF
--- a/src/phase2.hpp
+++ b/src/phase2.hpp
@@ -149,9 +149,9 @@ Phase2Results RunPhase2(
             uint16_t(entry_size),
             tmp_dirname,
             filename + ".p2.t" + std::to_string(table_index),
-            uint32_t(k + 1),
+            uint32_t(k) + 1,
             0,
-            strategy_t::quicksort);
+            strategy_t::quicksort_last);
 
         // as we scan the table for the second time, we'll also need to remap
         // the positions and offsets based on the next_bitfield.

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -373,7 +373,7 @@ Phase3Results RunPhase3(
             filename + ".p3s.t" + std::to_string(table_index + 1),
             0,
             0,
-            strategy_t::quicksort);
+            strategy_t::quicksort_last);
 
         std::vector<uint8_t> park_deltas;
         std::vector<uint64_t> park_stubs;

--- a/src/sort_manager.hpp
+++ b/src/sort_manager.hpp
@@ -35,6 +35,10 @@ enum class strategy_t : uint8_t
 {
     uniform,
     quicksort,
+
+    // the quicksort_last strategy is important because uniform sort performs
+    // really poorly on data that isn't actually uniformly distributed. The last
+    // buckets are often not uniformly distributed.
     quicksort_last,
 };
 

--- a/src/sort_manager.hpp
+++ b/src/sort_manager.hpp
@@ -273,12 +273,10 @@ private:
         uint64_t const bucket_entries = b.write_pointer / entry_size_;
         uint64_t const entries_fit_in_memory = this->memory_size_ / entry_size_;
 
-        uint32_t entry_len_memory = entry_size_ - begin_bits_ / 8;
-
         double const have_ram = entry_size_ * entries_fit_in_memory / (1024.0 * 1024.0 * 1024.0);
         double const qs_ram = entry_size_ * bucket_entries / (1024.0 * 1024.0 * 1024.0);
         double const u_ram =
-            Util::RoundSize(bucket_entries) * entry_len_memory / (1024.0 * 1024.0 * 1024.0);
+            Util::RoundSize(bucket_entries) * entry_size_ / (1024.0 * 1024.0 * 1024.0);
 
         if (bucket_entries > entries_fit_in_memory) {
             throw InsufficientMemoryException(
@@ -293,9 +291,9 @@ private:
             || (strategy_ == strategy_t::quicksort_last && last_bucket);
 
         // Do SortInMemory algorithm if it fits in the memory
-        // (number of entries required * entry_len_memory) <= total memory available
+        // (number of entries required * entry_size_) <= total memory available
         if (!force_quicksort &&
-            Util::RoundSize(bucket_entries) * entry_len_memory <= this->memory_size_) {
+            Util::RoundSize(bucket_entries) * entry_size_ <= memory_size_) {
             std::cout << "\tBucket " << bucket_i << " uniform sort. Ram: " << std::fixed
                       << std::setprecision(3) << have_ram << "GiB, u_sort min: " << u_ram
                       << "GiB, qs min: " << qs_ram << "GiB." << std::endl;

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -766,17 +766,15 @@ TEST_CASE("Sort on disk")
         }
 
         const uint32_t memory_len = Util::RoundSize(iters) * size;
-        uint8_t* memory = new uint8_t[memory_len];
-        UniformSort::SortToMemory(disk, begin, memory, size, iters, 16);
+        auto memory = std::make_unique<uint8_t[]>(memory_len);
+        UniformSort::SortToMemory(disk, begin, memory.get(), size, iters, 16);
 
         sort(input.begin(), input.end());
         uint8_t buf[size];
         for (uint32_t i = 0; i < iters; i++) {
             input[i].ToBytes(buf);
-            REQUIRE(memcmp(buf, memory + i * size, size) == 0);
+            REQUIRE(memcmp(buf, memory.get() + i * size, size) == 0);
         }
-
-        delete[] memory;
     }
 }
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -765,7 +765,7 @@ TEST_CASE("Sort on disk")
             input.emplace_back(Bits(hash.data(), size, size * 8));
         }
 
-        const uint32_t memory_len = Util::RoundSize(iters) * 30;
+        const uint32_t memory_len = Util::RoundSize(iters) * size;
         uint8_t* memory = new uint8_t[memory_len];
         UniformSort::SortToMemory(disk, begin, memory, size, iters, 16);
 


### PR DESCRIPTION
This fixes the uniform sort algorithm to accept a key (`begin_bit`) to start at an arbitrary place in the entries being sorted. Before this patch the uniform sort algorithm assumed the key started at bit 0, and that everything between 0 and `begin_bit` was a common prefix to all entries.

This issue does not affect QuickSort, as it supports this already.

With this support, phase2 can now use uniform sort again. This is believed to improve performance.

timing a *single* run of `ProofOfSpace -k 24` with this patch versus `master` give these timings:

This patch takes 17.035 seconds less, out of 112.836 seconds with `master`. i.e. 15% shorter run-time.

I think this is a net improvement.

This patch:
```
Total time = 95.801 seconds. CPU (99.060%) Wed Dec  9 17:27:42 2020
       96.29 real        86.37 user         8.59 sys
           469430272  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              410607  page reclaims
                   0  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                1099  voluntary context switches
               29312  involuntary context switches
        712575592158  instructions retired
        339941023224  cycles elapsed
           233426944  peak memory footprint
```

Compared to `master`:
```
Total time = 112.836 seconds. CPU (99.000%) Wed Dec  9 15:38:01 2020            
      113.16 real       103.25 user         8.52 sys                            
           527466496  maximum resident set size                                 
                   0  average shared memory size                                
                   0  average unshared data size                                
                   0  average unshared stack size                               
              354248  page reclaims                                             
                   0  page faults                                               
                   0  swaps                                                     
                   0  block input operations                                    
                   0  block output operations                                   
                   0  messages sent                                             
                   0  messages received                                         
                   0  signals received                                           
                1657  voluntary context switches                                
               18344  involuntary context switches                              
        835092806524  instructions retired
        400034587484  cycles elapsed
           208977920  peak memory footprint
```