### PR TITLE
Use try to avoid race condition on file glob

### DIFF
--- a/tests/plot-resources.py
+++ b/tests/plot-resources.py
@@ -45,7 +45,14 @@ def pollSpace():
     print("Temporary directory path is " + tempdirpath)
     used = 0
     while bPollSpace:
+<<<<<<< Updated upstream
         used = get_size(tempdirpath)
+=======
+        try:
+            used = get_size(tempdirpath)
+    except used.TempFileDeleted:
+    print("A temp file was deleted while polling. Skipping.")
+>>>>>>> Stashed changes
         if used > pollDisk:
             pollDisk = used
 

--- a/tests/plot-resources.py
+++ b/tests/plot-resources.py
@@ -43,11 +43,9 @@ def pollSpace():
 
     tempdirpath = os.getcwd() + "/" + tempdir
     print("Temporary directory path is " + tempdirpath)
+    used = 0
     while bPollSpace:
-        try:
-            used = get_size(tempdirpath)
-        except used.TempFileDeleted:
-            print("A temp file was deleted while polling. Skipping.")
+        used = get_size(tempdirpath)
         if used > pollDisk:
             pollDisk = used
 

--- a/tests/plot-resources.py
+++ b/tests/plot-resources.py
@@ -45,14 +45,10 @@ def pollSpace():
     print("Temporary directory path is " + tempdirpath)
     used = 0
     while bPollSpace:
-<<<<<<< Updated upstream
-        used = get_size(tempdirpath)
-=======
         try:
             used = get_size(tempdirpath)
-    except used.TempFileDeleted:
-    print("A temp file was deleted while polling. Skipping.")
->>>>>>> Stashed changes
+        except used.TempFileDeleted:
+            print("A temp file was deleted while polling. Skipping.")
         if used > pollDisk:
             pollDisk = used
 

--- a/tests/plot-resources.py
+++ b/tests/plot-resources.py
@@ -44,7 +44,10 @@ def pollSpace():
     tempdirpath = os.getcwd() + "/" + tempdir
     print("Temporary directory path is " + tempdirpath)
     while bPollSpace:
-        used = get_size(tempdirpath)
+        try:
+            used = get_size(tempdirpath)
+        except used.TempFileDeleted:
+            print("A temp file was deleted while polling. Skipping.")
         if used > pollDisk:
             pollDisk = used
 


### PR DESCRIPTION
When the background polling thread is running it can have a .tmp file found in it's glob of the directory that gets deleted before it can stat it.