### PR TITLE
Have ProofOfSpace mirror chia-blockchain's -r - fix temp space accumulator

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) try {
 
     options.allow_unrecognised_options().add_options()(
             "k, size", "Plot size", cxxopts::value<uint8_t>(k))(
-            "h, threads", "Number of threads", cxxopts::value<uint8_t>(num_threads))(
+            "r, threads", "Number of threads", cxxopts::value<uint8_t>(num_threads))(
                 "u, buckets", "Number of buckets", cxxopts::value<uint32_t>(num_buckets))(
             "s, stripes", "Size of stripes", cxxopts::value<uint32_t>(num_stripes))(
             "t, tempdir", "Temporary directory", cxxopts::value<string>(tempdir))(

--- a/tests/plot-resources.py
+++ b/tests/plot-resources.py
@@ -47,8 +47,9 @@ def pollSpace():
     while bPollSpace:
         try:
             used = get_size(tempdirpath)
-        except used.TempFileDeleted:
-            print("A temp file was deleted while polling. Skipping.")
+        except FileNotFoundError:
+            print("A temp file was deleted while polling the temp directory. Skipping.")
+            pass
         if used > pollDisk:
             pollDisk = used
 
@@ -74,7 +75,7 @@ def run_ProofOfSpace(k_size):
         cmd = (
             "exec ./ProofOfSpace create -k "
             + k_size
-            + " -r 2"
+            + " -r 1"
             + " -b 4608"
             + " -u 64"
             + " -t "

--- a/tests/plot-resources.py
+++ b/tests/plot-resources.py
@@ -75,7 +75,7 @@ def run_ProofOfSpace(k_size):
         cmd = (
             "exec ./ProofOfSpace create -k "
             + k_size
-            + " -r 1"
+            + " -r 2"
             + " -b 4608"
             + " -u 64"
             + " -t "

--- a/tests/plot-resources.py
+++ b/tests/plot-resources.py
@@ -75,7 +75,7 @@ def run_ProofOfSpace(k_size):
         cmd = (
             "exec ./ProofOfSpace create -k "
             + k_size
-            + " -r 2"
+            + " -r 1"
             + " -b 4608"
             + " -u 64"
             + " -t "


### PR DESCRIPTION
Using two threads is a nearly 30% speedup and we should move to that once we've gotten a new baseline so that the CI runs faster.