### PR TITLE
Upgrade to current uint128

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) try {
 
     options.allow_unrecognised_options().add_options()(
             "k, size", "Plot size", cxxopts::value<uint8_t>(k))(
-            "h, threads", "Number of threads", cxxopts::value<uint8_t>(num_threads))(
+            "r, threads", "Number of threads", cxxopts::value<uint8_t>(num_threads))(
                 "u, buckets", "Number of buckets", cxxopts::value<uint32_t>(num_buckets))(
             "s, stripes", "Size of stripes", cxxopts::value<uint32_t>(num_stripes))(
             "t, tempdir", "Temporary directory", cxxopts::value<string>(tempdir))(

--- a/tests/plot-resources.py
+++ b/tests/plot-resources.py
@@ -47,8 +47,9 @@ def pollSpace():
     while bPollSpace:
         try:
             used = get_size(tempdirpath)
-        except used.TempFileDeleted:
-            print("A temp file was deleted while polling. Skipping.")
+        except FileNotFoundError:
+            print("A temp file was deleted while polling the temp directory. Skipping.")
+            pass
         if used > pollDisk:
             pollDisk = used
 
@@ -74,7 +75,7 @@ def run_ProofOfSpace(k_size):
         cmd = (
             "exec ./ProofOfSpace create -k "
             + k_size
-            + " -r 2"
+            + " -r 1"
             + " -b 4608"
             + " -u 64"
             + " -t "

--- a/tests/plot-resources.py
+++ b/tests/plot-resources.py
@@ -75,7 +75,7 @@ def run_ProofOfSpace(k_size):
         cmd = (
             "exec ./ProofOfSpace create -k "
             + k_size
-            + " -r 1"
+            + " -r 2"
             + " -b 4608"
             + " -u 64"
             + " -t "

--- a/tests/plot-resources.py
+++ b/tests/plot-resources.py
@@ -75,7 +75,7 @@ def run_ProofOfSpace(k_size):
         cmd = (
             "exec ./ProofOfSpace create -k "
             + k_size
-            + " -r 2"
+            + " -r 1"
             + " -b 4608"
             + " -u 64"
             + " -t "


### PR DESCRIPTION
This would bring us current to https://github.com/calccrypto/uint128_t/commit/00714e6059d7d0d111b68a8fd9ee609094da3c0a

It's not a priority but I was tired of that other warning. Also we should probably be cmake fetching this instead...

It's throwing:
```
In file included from /Users/hoffmang/beta/chiapos/python-bindings/chiapos.cpp:22:
In file included from /Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/operators.h:12:
In file included from /Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/pybind11.h:44:
In file included from /Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/attr.h:13:
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/cast.h:2058:26: warning: loop
      variable 'a' is always a copy because the range of type 'detail::args_proxy' does not return a
      reference [-Wrange-loop-analysis]
        for (const auto &a : ap)
                         ^
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/cast.h:2058:14: note: use
      non-reference type 'pybind11::handle'
        for (const auto &a : ap)
             ^~~~~~~~~~~~~~~
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/cast.h:2090:26: warning: loop
      variable 'k' is always a copy because the range of type 'pybind11::dict' does not return a reference
      [-Wrange-loop-analysis]
        for (const auto &k : reinterpret_borrow<dict>(kp)) {
                         ^
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/cast.h:2090:14: note: use
      non-reference type 'std::__1::pair<pybind11::handle, pybind11::handle>'
        for (const auto &k : reinterpret_borrow<dict>(kp)) {
             ^~~~~~~~~~~~~~~
In file included from /Users/hoffmang/beta/chiapos/python-bindings/chiapos.cpp:22:
In file included from /Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/operators.h:12:
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/pybind11.h:1415:34: warning: loop
      variable 'kv' is always a copy because the range of type 'pybind11::dict' does not return a reference
      [-Wrange-loop-analysis]
                for (const auto &kv : entries) {
                                 ^
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/pybind11.h:1415:22: note: use
      non-reference type 'std::__1::pair<pybind11::handle, pybind11::handle>'
                for (const auto &kv : entries) {
                     ^~~~~~~~~~~~~~~~
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/pybind11.h:1427:34: warning: loop
      variable 'kv' is always a copy because the range of type 'pybind11::dict' does not return a reference
      [-Wrange-loop-analysis]
                for (const auto &kv : entries) {
                                 ^
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/pybind11.h:1427:22: note: use
      non-reference type 'std::__1::pair<pybind11::handle, pybind11::handle>'
                for (const auto &kv : entries) {
                     ^~~~~~~~~~~~~~~~
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/pybind11.h:1442:34: warning: loop
      variable 'kv' is always a copy because the range of type 'pybind11::dict' does not return a reference
      [-Wrange-loop-analysis]
                for (const auto &kv : entries) {
                                 ^
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/pybind11.h:1442:22: note: use
      non-reference type 'std::__1::pair<pybind11::handle, pybind11::handle>'
                for (const auto &kv : entries) {
                     ^~~~~~~~~~~~~~~~
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/pybind11.h:1456:34: warning: loop
      variable 'kv' is always a copy because the range of type 'pybind11::dict' does not return a reference
      [-Wrange-loop-analysis]
                for (const auto &kv : entries)
                                 ^
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/pybind11.h:1456:22: note: use
      non-reference type 'std::__1::pair<pybind11::handle, pybind11::handle>'
                for (const auto &kv : entries)
                     ^~~~~~~~~~~~~~~~
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/pybind11.h:1544:26: warning: loop
      variable 'kv' is always a copy because the range of type 'pybind11::dict' does not return a reference
      [-Wrange-loop-analysis]
        for (const auto &kv : entries)
                         ^
/Users/hoffmang/beta/chiapos/build/_deps/pybind11-src-src/include/pybind11/pybind11.h:1544:14: note: use
      non-reference type 'std::__1::pair<pybind11::handle, pybind11::handle>'
        for (const auto &kv : entries)
             ^~~~~~~~~~~~~~~~
```