### PR TITLE
Fix buffered disk

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -880,10 +880,10 @@ TEST_CASE("bitfield_index edge-cases")
     CHECK(idx.lookup(bitfield_index::kIndexBucket, 0) == std::pair<uint64_t, uint64_t>{1,0});
     CHECK(idx.lookup(bitfield_index::kIndexBucket, bitfield_index::kIndexBucket) == std::pair<uint64_t, uint64_t>{1,1});
     CHECK(idx.lookup(bitfield_index::kIndexBucket, 1048576 - 1 - bitfield_index::kIndexBucket)
-		== std::pair<uint64_t, uint64_t>{1,2});
+        == std::pair<uint64_t, uint64_t>{1,2});
 
-	CHECK(idx.lookup(bitfield_index::kIndexBucket * 2, 1048576 - 1 - bitfield_index::kIndexBucket * 2)
-		== std::pair<uint64_t, uint64_t>{2,1});
+    CHECK(idx.lookup(bitfield_index::kIndexBucket * 2, 1048576 - 1 - bitfield_index::kIndexBucket * 2)
+        == std::pair<uint64_t, uint64_t>{2,1});
     CHECK(idx.lookup(1048576 - 1, 0) == std::pair<uint64_t, uint64_t>{3,0});
 }
 
@@ -900,7 +900,7 @@ void test_bitfield_size(int const size)
 
 TEST_CASE("bitfield_index edge-sizes")
 {
-	test_bitfield_size(bitfield_index::kIndexBucket - 1);
-	test_bitfield_size(bitfield_index::kIndexBucket);
-	test_bitfield_size(bitfield_index::kIndexBucket + 1);
+    test_bitfield_size(bitfield_index::kIndexBucket - 1);
+    test_bitfield_size(bitfield_index::kIndexBucket);
+    test_bitfield_size(bitfield_index::kIndexBucket + 1);
 }


### PR DESCRIPTION
This fix two performance issues in one layer of the disk abstraction `BufferedDisk`.
It also turns an assert into a warning log. This was uncovered by me hitting this assert while testing a k32 under address sanitizer.

descriptions are inline.