### PR TITLE
Add Dockerile for Ubuntu 20.04

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*
+!lib/
+!python-bindings/
+!src/
+!tests/
+!tools/
+!uint128_t/
+!CMakeLists.txt
+!LICENSE
+!README.md
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:20.04 as builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y
+
+RUN apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  cmake \
+  git \
+  python3 \
+  python3-dev \
+  python3-distutils \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+RUN mkdir -p build
+
+WORKDIR /app/build
+RUN cmake ../
+RUN cmake --build . -- -j `nproc`
+
+
+FROM ubuntu:20.04
+
+COPY --from=builder /app/build /app
+
+CMD ["/app/ProofOfSpace"]
+

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker build -t chiapos:dev .
+

--- a/docker-test.sh
+++ b/docker-test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker run -it --rm chiapos:dev /app/RunTests
+


### PR DESCRIPTION
Support building using Docker. Simplifies checking for breaking changes on Linux when developing on MacOS.