### PR TITLE
Fix wrong default for --no-bitfield option in CI test script

### DIFF
--- a/tests/plot-resources.py
+++ b/tests/plot-resources.py
@@ -45,7 +45,7 @@ def create_parser() -> ArgumentParser:
         "--no-bitfield",
         action="store_true",
         help="Disable using bitfield sort.",
-        default="False",
+        default=False,
     )
     return parser
 


### PR DESCRIPTION
Get the CI to actually test plotting with bitfield enabled (the intended
default behavior).