### PR TITLE
Remove pybind11 submodule - fetch content working

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/pybind11"]
-	path = lib/pybind11
-	url = https://github.com/pybind/pybind11.git


### PR DESCRIPTION
Remove the pybind submodule since we're using fetch content in Cmake.