### PR TITLE
make the read and write disk caches smaller

### DIFF
--- a/src/disk.hpp
+++ b/src/disk.hpp
@@ -35,8 +35,8 @@ using namespace std::chrono_literals; // for operator""min;
 #include "./util.hpp"
 #include "bitfield.hpp"
 
-constexpr uint64_t write_cache = 4 * 1024 * 1024;
-constexpr uint64_t read_ahead = 4 * 1024 * 1024;
+constexpr uint64_t write_cache = 1024 * 1024;
+constexpr uint64_t read_ahead = 1024 * 1024;
 
 struct Disk {
     virtual uint8_t const* Read(uint64_t begin, uint64_t length) = 0;


### PR DESCRIPTION
4 MiB -> 1 MiB. These are multiplied by the number of buckets.
the larger cache size is believed to not contribute to any performance improvements.