### PR TITLE
Shrink entry sizes to reduce memory and IO usage

### DIFF
--- a/src/b17phase2.hpp
+++ b/src/b17phase2.hpp
@@ -210,7 +210,7 @@ std::vector<uint64_t> b17RunPhase2(
                             entry_offset =
                                 Util::SliceInt64FromBytes(right_entry_buf, pos_size, kOffsetSize);
                             entry_sort_key = Util::SliceInt64FromBytes(
-                                right_entry_buf, pos_size + kOffsetSize, k + 1);
+                                right_entry_buf, pos_size + kOffsetSize, k);
                         }
                     } else if (cached_entry_pos == current_pos) {
                         // We have a cached entry at this position
@@ -295,7 +295,7 @@ std::vector<uint64_t> b17RunPhase2(
                             // use this instead of (y + pos + offset) since its smaller.
                             new_left_entry += Bits(entry_pos, pos_size);
                             new_left_entry += Bits(entry_offset, kOffsetSize);
-                            new_left_entry += Bits(left_entry_counter, k + 1);
+                            new_left_entry += Bits(left_entry_counter, k);
 
                             // If we are not taking up all the bits, make sure they are zeroed
                             if (Util::ByteAlign(new_left_entry.GetSize()) < left_entry_size_bytes * 8) {
@@ -348,7 +348,7 @@ std::vector<uint64_t> b17RunPhase2(
                             ? Bits(old_sort_keys[write_pointer_pos % kReadMinusWrite][counter], k)
                             : Bits(
                                   old_sort_keys[write_pointer_pos % kReadMinusWrite][counter],
-                                  k + 1);
+                                  k);
                     new_right_entry += new_pos_bin;
                     // match_positions.push_back(std::make_pair(new_pos, new_offset_pos));
                     new_right_entry.AppendValue(new_offset_pos - new_pos, kOffsetSize);

--- a/src/b17phase3.hpp
+++ b/src/b17phase3.hpp
@@ -62,6 +62,7 @@ b17Phase3Results b17RunPhase3(
     const bool show_progress)
 {
     uint8_t pos_size = k;
+    uint8_t line_point_size = 2 * k - 1;
 
     std::vector<uint64_t> final_table_begin_pointers(12, 0);
     final_table_begin_pointers[1] = header_size;
@@ -103,7 +104,7 @@ b17Phase3Results b17RunPhase3(
 
         // Sort key for table 7 is just y, which is k bits. For all other tables it can
         // be higher than 2^k and therefore k+1 bits are used.
-        uint32_t right_sort_key_size = table_index == 6 ? k : k + 1;
+        uint32_t right_sort_key_size = k;
 
         uint32_t left_entry_size_bytes = EntrySizes::GetMaxEntrySize(k, table_index, false);
         right_entry_size_bytes = EntrySizes::GetMaxEntrySize(k, table_index + 1, false);
@@ -258,7 +259,7 @@ b17Phase3Results b17RunPhase3(
                 } else {
                     // k+1 bits in case it overflows
                     left_new_pos[current_pos % kCachedPositionsSize] =
-                        Util::SliceInt64FromBytes(left_entry_disk_buf, k + 1, k + 1);
+                        Util::SliceInt64FromBytes(left_entry_disk_buf, right_sort_key_size, k);
                 }
             }
 
@@ -289,7 +290,7 @@ b17Phase3Results b17RunPhase3(
                             abort();
                         }
                     }
-                    Bits to_write = Bits(line_point, 2 * k);
+                    Bits to_write = Bits(line_point, line_point_size);
                     to_write += Bits(
                         old_sort_keys[write_pointer_pos % kReadMinusWrite][counter],
                         right_sort_key_size);
@@ -357,19 +358,20 @@ b17Phase3Results b17RunPhase3(
         // groups(parks), with a checkpoint in each group.
         Bits right_entry_bits;
         int added_to_cache = 0;
+        uint8_t index_size = table_index == 6 ? k + 1 : k;
         for (uint64_t index = 0; index < total_r_entries; index++) {
             right_reader_entry_buf = R_sort_manager->ReadEntry(right_reader, 2);
             right_reader += right_entry_size_bytes;
             right_reader_count++;
 
             // Right entry is read as (line_point, sort_key)
-            uint128_t line_point = Util::SliceInt128FromBytes(right_reader_entry_buf, 0, 2 * k);
+            uint128_t line_point = Util::SliceInt128FromBytes(right_reader_entry_buf, 0, line_point_size);
             uint64_t sort_key =
-                Util::SliceInt64FromBytes(right_reader_entry_buf, 2 * k, right_sort_key_size);
+                Util::SliceInt64FromBytes(right_reader_entry_buf, line_point_size, right_sort_key_size);
 
             // Write the new position (index) and the sort key
             Bits to_write = Bits(sort_key, right_sort_key_size);
-            to_write += Bits(index, k + 1);
+            to_write += Bits(index, index_size);
 
             L_sort_manager->AddToCache(to_write);
             added_to_cache++;

--- a/src/entry_sizes.hpp
+++ b/src/entry_sizes.hpp
@@ -70,6 +70,13 @@ public:
         }
     }
 
+    // Get size of entries containing (sort_key, pos, offset). Such entries are
+    // written to table 7 in phase 1 and to tables 2-7 in phase 2.
+    static uint32_t GetKeyPosOffsetSize(uint8_t k)
+    {
+        return cdiv(2 * k + kOffsetSize, 8);
+    }
+
     // Calculates the size of one C3 park. This will store bits for each f7 between
     // two C1 checkpoints, depending on how many times that f7 is present. For low
     // values of k, we need extra space to account for the additional variability.

--- a/src/entry_sizes.hpp
+++ b/src/entry_sizes.hpp
@@ -61,12 +61,12 @@ public:
                     //    b:  line_point, sort_key
                     return Util::ByteAlign(
                                std::max(static_cast<uint32_t>(2 * k + kOffsetSize),
-                                   static_cast<uint32_t>(3 * k))) /
+                                   static_cast<uint32_t>(3 * k - 1))) /
                            8;
             case 7:
             default:
                 // Represents line_point, f7
-                return Util::ByteAlign(3 * k) / 8;
+                return Util::ByteAlign(3 * k - 1) / 8;
         }
     }
 

--- a/src/entry_sizes.hpp
+++ b/src/entry_sizes.hpp
@@ -60,8 +60,8 @@ public:
                     //    a:  sort_key, pos, offset        or
                     //    b:  line_point, sort_key
                     return Util::ByteAlign(
-                               std::max(static_cast<uint32_t>(k + 1 + (k) + kOffsetSize),
-                                   static_cast<uint32_t>(2 * k + k + 1))) /
+                               std::max(static_cast<uint32_t>(2 * k + kOffsetSize),
+                                   static_cast<uint32_t>(3 * k))) /
                            8;
             case 7:
             default:

--- a/src/phase2.hpp
+++ b/src/phase2.hpp
@@ -52,11 +52,11 @@ Phase2Results RunPhase2(
     uint32_t const log_num_buckets,
     bool const show_progress)
 {
-    // An extra bit is used, since we may have more than 2^k entries in a table. (After pruning,
-    // each table will have 0.8*2^k or fewer entries).
+    // After pruning each table will have 0.865 * 2^k or fewer entries on
+    // average
     uint8_t const pos_size = k;
     uint8_t const pos_offset_size = pos_size + kOffsetSize;
-    uint8_t const write_counter_shift = 128 - (k + 1);
+    uint8_t const write_counter_shift = 128 - k;
     uint8_t const pos_offset_shift = write_counter_shift - pos_offset_size;
     uint8_t const f7_shift = 128 - k;
     uint8_t const t7_pos_offset_shift = f7_shift - pos_offset_size;
@@ -160,7 +160,7 @@ Phase2Results RunPhase2(
             uint16_t(entry_size),
             tmp_dirname,
             filename + ".p2.t" + std::to_string(table_index),
-            uint32_t(k) + 1,
+            uint32_t(k),
             0,
             strategy_t::quicksort_last);
 

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -335,7 +335,7 @@ Phase3Results RunPhase3(
                         }
                     }
                     Bits to_write = Bits(line_point, 2 * k);
-                    to_write += Bits(
+                    to_write.AppendValue(
                         old_sort_keys[write_pointer_pos % kReadMinusWrite][counter],
                         right_sort_key_size);
 

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -303,7 +303,7 @@ Phase3Results RunPhase3(
                 } else {
                     // k+1 bits in case it overflows
                     left_new_pos[current_pos % kCachedPositionsSize] =
-                        Util::SliceInt64FromBytes(left_entry_disk_buf, right_sort_key_size, k + 1);
+                        Util::SliceInt64FromBytes(left_entry_disk_buf, right_sort_key_size, k);
                 }
             }
 
@@ -397,7 +397,7 @@ Phase3Results RunPhase3(
         // groups(parks), with a checkpoint in each group.
         int added_to_cache = 0;
         uint8_t const sort_key_shift = 128 - right_sort_key_size;
-        uint8_t const index_shift = sort_key_shift - (k + 1);
+        uint8_t const index_shift = sort_key_shift - (k + (table_index == 6 ? 1 : 0));
         for (uint64_t index = 0; index < total_r_entries; index++) {
             right_reader_entry_buf = R_sort_manager->ReadEntry(right_reader);
             right_reader += right_entry_size_bytes;

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -130,8 +130,8 @@ Phase3Results RunPhase3(
     uint32_t log_num_buckets,
     const bool show_progress)
 {
-    uint8_t pos_size = k;
-    uint8_t line_point_size = 2 * k - 1;
+    uint8_t const pos_size = k;
+    uint8_t const line_point_size = 2 * k - 1;
 
     std::vector<uint64_t> final_table_begin_pointers(12, 0);
     final_table_begin_pointers[1] = header_size;

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -173,9 +173,10 @@ Phase3Results RunPhase3(
         Disk& right_disk = res2.disk_for_table(table_index + 1);
         Disk& left_disk = res2.disk_for_table(table_index);
 
-        // Sort key for table 7 is just y, which is k bits. For all other tables it can
-        // be higher than 2^k and therefore k+1 bits are used.
-        uint32_t right_sort_key_size = table_index == 6 ? k : k + 1;
+        // Sort key is k bits for all tables. For table 7 it is just y, which
+        // is k bits, and for all other tables the number of entries does not
+        // exceed 0.865 * 2^k on average.
+        uint32_t right_sort_key_size = k;
 
         uint32_t left_entry_size_bytes = EntrySizes::GetMaxEntrySize(k, table_index, false);
         right_entry_size_bytes = EntrySizes::GetMaxEntrySize(k, table_index + 1, false);
@@ -302,7 +303,7 @@ Phase3Results RunPhase3(
                 } else {
                     // k+1 bits in case it overflows
                     left_new_pos[current_pos % kCachedPositionsSize] =
-                        Util::SliceInt64FromBytes(left_entry_disk_buf, k + 1, k + 1);
+                        Util::SliceInt64FromBytes(left_entry_disk_buf, right_sort_key_size, k + 1);
                 }
             }
 

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -131,6 +131,7 @@ Phase3Results RunPhase3(
     const bool show_progress)
 {
     uint8_t pos_size = k;
+    uint8_t line_point_size = 2 * k - 1;
 
     std::vector<uint64_t> final_table_begin_pointers(12, 0);
     final_table_begin_pointers[1] = header_size;
@@ -334,7 +335,7 @@ Phase3Results RunPhase3(
                             abort();
                         }
                     }
-                    Bits to_write = Bits(line_point, 2 * k);
+                    Bits to_write = Bits(line_point, line_point_size);
                     to_write.AppendValue(
                         old_sort_keys[write_pointer_pos % kReadMinusWrite][counter],
                         right_sort_key_size);
@@ -404,9 +405,9 @@ Phase3Results RunPhase3(
             right_reader_count++;
 
             // Right entry is read as (line_point, sort_key)
-            uint128_t line_point = Util::SliceInt128FromBytes(right_reader_entry_buf, 0, 2 * k);
+            uint128_t line_point = Util::SliceInt128FromBytes(right_reader_entry_buf, 0, line_point_size);
             uint64_t sort_key =
-                Util::SliceInt64FromBytes(right_reader_entry_buf, 2 * k, right_sort_key_size);
+                Util::SliceInt64FromBytes(right_reader_entry_buf, line_point_size, right_sort_key_size);
 
             // Write the new position (index) and the sort key
             uint128_t to_write = (uint128_t)sort_key << sort_key_shift;

--- a/src/phase3.hpp
+++ b/src/phase3.hpp
@@ -181,6 +181,7 @@ Phase3Results RunPhase3(
         uint32_t right_sort_key_size = k;
 
         uint32_t left_entry_size_bytes = EntrySizes::GetMaxEntrySize(k, table_index, false);
+        uint32_t p2_entry_size_bytes = EntrySizes::GetKeyPosOffsetSize(k);
         right_entry_size_bytes = EntrySizes::GetMaxEntrySize(k, table_index + 1, false);
 
         uint64_t left_reader = 0;
@@ -242,8 +243,8 @@ Phase3Results RunPhase3(
                         }
                         // The right entries are in the format from backprop, (sort_key, pos,
                         // offset)
-                        uint8_t const* right_entry_buf = right_disk.Read(right_reader, right_entry_size_bytes);
-                        right_reader += right_entry_size_bytes;
+                        uint8_t const* right_entry_buf = right_disk.Read(right_reader, p2_entry_size_bytes);
+                        right_reader += p2_entry_size_bytes;
                         right_reader_count++;
 
                         entry_sort_key =

--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -227,6 +227,7 @@ public:
                 log_num_buckets,
                 stripe_size,
                 num_threads,
+                !nobitfield,
                 show_progress);
             p1.PrintElapsed("Time for phase 1 =");
 


### PR DESCRIPTION
Efficient plotting of k=32 with 2 threads is now possible with buffer size of 3389 MiB.