### PR TITLE
Prevent chiapos prover crashing for bad plots

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -270,7 +270,7 @@ int main(int argc, char *argv[]) try {
                     }
                     delete[] proof_data;
                 }
-            } catch (const std::exception error) {
+            } catch (const std::exception& error) {
                 cout << "Threw: " << error.what() << endl;
                 continue;
             }

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -247,18 +247,28 @@ private:
     static void SafeSeek(std::ifstream& disk_file, uint64_t seek_location) {
         disk_file.seekg(seek_location);
 
-        if (disk_file.bad() || disk_file.fail()) {
-            std::cout << "goodbit, failbit, badbit, eofbit: " <<   (disk_file.rdstate() & std::ifstream::goodbit) <<  (disk_file.rdstate() & std::ifstream::failbit) << (disk_file.rdstate() & std::ifstream::badbit) << (disk_file.rdstate() & std::ifstream::eofbit) << std::endl;
-            throw std::runtime_error("badbit or failbit after seeking to" + std::to_string(seek_location));
+        if (disk_file.fail()) {
+            std::cout << "goodbit, failbit, badbit, eofbit: "
+                      << (disk_file.rdstate() & std::ifstream::goodbit)
+                      << (disk_file.rdstate() & std::ifstream::failbit)
+                      << (disk_file.rdstate() & std::ifstream::badbit)
+                      << (disk_file.rdstate() & std::ifstream::eofbit)
+                      << std::endl;
+            throw std::runtime_error("badbit or failbit after seeking to " + std::to_string(seek_location));
         }
     }
 
     static void SafeRead(std::ifstream& disk_file, uint8_t* target, uint64_t size) {
         disk_file.read(reinterpret_cast<char*>(target), size);
 
-        if (disk_file.bad() || disk_file.fail()) {
-            std::cout << "goodbit, failbit, badbit, eofbit: " <<   (disk_file.rdstate() & std::ifstream::goodbit) <<  (disk_file.rdstate() & std::ifstream::failbit) << (disk_file.rdstate() & std::ifstream::badbit) << (disk_file.rdstate() & std::ifstream::eofbit) << std::endl;
-            throw std::runtime_error("badbit or failbit after reading size" + std::to_string(size));
+        if (disk_file.fail()) {
+            std::cout << "goodbit, failbit, badbit, eofbit: "
+                      << (disk_file.rdstate() & std::ifstream::goodbit)
+                      << (disk_file.rdstate() & std::ifstream::failbit)
+                      << (disk_file.rdstate() & std::ifstream::badbit)
+                      << (disk_file.rdstate() & std::ifstream::eofbit)
+                      << std::endl;
+            throw std::runtime_error("badbit or failbit after reading size " + std::to_string(size));
         }
     }
 

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -259,6 +259,7 @@ private:
     }
 
     static void SafeRead(std::ifstream& disk_file, uint8_t* target, uint64_t size) {
+        int64_t pos = disk_file.tellg();
         disk_file.read(reinterpret_cast<char*>(target), size);
 
         if (disk_file.fail()) {
@@ -268,7 +269,8 @@ private:
                       << (disk_file.rdstate() & std::ifstream::badbit)
                       << (disk_file.rdstate() & std::ifstream::eofbit)
                       << std::endl;
-            throw std::runtime_error("badbit or failbit after reading size " + std::to_string(size));
+            throw std::runtime_error("badbit or failbit after reading size " +
+                    std::to_string(size) + " at position " + std::to_string(pos));
         }
     }
 

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -67,7 +67,7 @@ public:
         // 2 bytes   - memo length
         // x bytes   - memo
 
-        safeRead(disk_file, (uint8_t*)&header, sizeof(header));
+        SafeRead(disk_file, (uint8_t*)&header, sizeof(header));
         if (memcmp(header.magic, "Proof of Space Plot", sizeof(header.magic)) != 0)
             throw std::invalid_argument("Invalid plot header magic");
 
@@ -82,24 +82,24 @@ public:
 
         memcpy(this->id, header.id, sizeof(header.id));
         this->k = header.k;
-        safeSeek(disk_file, offsetof(struct plot_header, fmt_desc) + fmt_desc_len);
+        SafeSeek(disk_file, offsetof(struct plot_header, fmt_desc) + fmt_desc_len);
 
         uint8_t size_buf[2];
-        safeRead(disk_file, size_buf, 2);
+        SafeRead(disk_file, size_buf, 2);
         this->memo_size = Util::TwoBytesToInt(size_buf);
         this->memo = new uint8_t[this->memo_size];
-        safeRead(disk_file, this->memo, this->memo_size);
+        SafeRead(disk_file, this->memo, this->memo_size);
 
         this->table_begin_pointers = std::vector<uint64_t>(11, 0);
         this->C2 = std::vector<uint64_t>();
 
         uint8_t pointer_buf[8];
         for (uint8_t i = 1; i < 11; i++) {
-            safeRead(disk_file, pointer_buf, 8);
+            SafeRead(disk_file, pointer_buf, 8);
             this->table_begin_pointers[i] = Util::EightBytesToInt(pointer_buf);
         }
 
-        safeSeek(disk_file, table_begin_pointers[9]);
+        SafeSeek(disk_file, table_begin_pointers[9]);
 
         uint8_t c2_size = (Util::ByteAlign(k) / 8);
         uint32_t c2_entries = (table_begin_pointers[10] - table_begin_pointers[9]) / c2_size;
@@ -111,7 +111,7 @@ public:
         // read from disk the C1 and C3 entries.
         auto* c2_buf = new uint8_t[c2_size];
         for (uint32_t i = 0; i < c2_entries - 1; i++) {
-            safeRead(disk_file, c2_buf, c2_size);
+            SafeRead(disk_file, c2_buf, c2_size);
             this->C2.push_back(Bits(c2_buf, c2_size, c2_size * 8).Slice(0, k).GetValue());
         }
 
@@ -244,27 +244,21 @@ private:
 
     // Using this method instead of simply seeking will prevent segfaults that would arise when
     // continuing the process of looking up qualities.
-    void safeSeek(std::ifstream& disk_file, uint64_t seek_location) {
-        if ((disk_file.rdstate() & std::ifstream::goodbit) != 0) {
-            throw std::invalid_argument("safeSeed: provided input stream goodbit != 0.");
-        }
-
+    static void SafeSeek(std::ifstream& disk_file, uint64_t seek_location) {
         disk_file.seekg(seek_location);
 
-        if ((disk_file.rdstate() & std::ifstream::goodbit) != 0) {
+        if (disk_file.bad() || disk_file.fail()) {
             std::cout << "goodbit, failbit, badbit, eofbit: " <<   (disk_file.rdstate() & std::ifstream::goodbit) <<  (disk_file.rdstate() & std::ifstream::failbit) << (disk_file.rdstate() & std::ifstream::badbit) << (disk_file.rdstate() & std::ifstream::eofbit) << std::endl;
-            throw std::runtime_error("goodbit!=0 after seeking to" + std::to_string(seek_location));
+            throw std::runtime_error("badbit or failbit after seeking to" + std::to_string(seek_location));
         }
     }
 
-    void safeRead(std::ifstream& disk_file, uint8_t* target, uint64_t size) {
-        if ((disk_file.rdstate() & std::ifstream::goodbit) != 0) {
-            throw std::invalid_argument("safeRead: rovided input stream goodbit != 0.");
-        }
+    static void SafeRead(std::ifstream& disk_file, uint8_t* target, uint64_t size) {
         disk_file.read(reinterpret_cast<char*>(target), size);
-        if ((disk_file.rdstate() & std::ifstream::goodbit) != 0) {
+
+        if (disk_file.bad() || disk_file.fail()) {
             std::cout << "goodbit, failbit, badbit, eofbit: " <<   (disk_file.rdstate() & std::ifstream::goodbit) <<  (disk_file.rdstate() & std::ifstream::failbit) << (disk_file.rdstate() & std::ifstream::badbit) << (disk_file.rdstate() & std::ifstream::eofbit) << std::endl;
-            throw std::runtime_error("goodbit!=0 after reading size" + std::to_string(size));
+            throw std::runtime_error("badbit or failbit after reading size" + std::to_string(size));
         }
     }
 
@@ -277,18 +271,18 @@ private:
         uint64_t park_index = position / kEntriesPerPark;
         uint32_t park_size_bits = EntrySizes::CalculateParkSize(k, table_index) * 8;
 
-        safeSeek(disk_file, table_begin_pointers[table_index] + (park_size_bits / 8) * park_index);
+        SafeSeek(disk_file, table_begin_pointers[table_index] + (park_size_bits / 8) * park_index);
 
         // This is the checkpoint at the beginning of the park
         uint16_t line_point_size = EntrySizes::CalculateLinePointSize(k);
         auto* line_point_bin = new uint8_t[line_point_size + 7];
-        safeRead(disk_file, line_point_bin, line_point_size);
+        SafeRead(disk_file, line_point_bin, line_point_size);
         uint128_t line_point = Util::SliceInt128FromBytes(line_point_bin, 0, k * 2);
 
         // Reads EPP stubs
         uint32_t stubs_size_bits = EntrySizes::CalculateStubsSize(k) * 8;
         auto* stubs_bin = new uint8_t[stubs_size_bits / 8 + 7];
-        safeRead(disk_file, stubs_bin, stubs_size_bits/8);
+        SafeRead(disk_file, stubs_bin, stubs_size_bits / 8);
 
         // Reads EPP deltas
         uint32_t max_deltas_size_bits = EntrySizes::CalculateMaxDeltasSize(k, table_index) * 8;
@@ -296,7 +290,7 @@ private:
 
         // Reads the size of the encoded deltas object
         uint16_t encoded_deltas_size = 0;
-        safeRead(disk_file, (uint8_t*)&encoded_deltas_size, sizeof(uint16_t));
+        SafeRead(disk_file, (uint8_t*)&encoded_deltas_size, sizeof(uint16_t));
 
         if (encoded_deltas_size * 8 > max_deltas_size_bits) {
             throw std::invalid_argument("Invalid size for deltas: " + std::to_string(encoded_deltas_size));
@@ -308,10 +302,10 @@ private:
             // Uncompressed
             encoded_deltas_size &= 0x7fff;
             deltas.resize(encoded_deltas_size);
-            safeRead(disk_file, deltas.data(), encoded_deltas_size);
+            SafeRead(disk_file, deltas.data(), encoded_deltas_size);
         } else {
             // Compressed
-            safeRead(disk_file, deltas_bin, encoded_deltas_size);
+            SafeRead(disk_file, deltas_bin, encoded_deltas_size);
 
             // Decodes the deltas
             double R = kRValues[table_index - 1];
@@ -426,14 +420,14 @@ private:
         uint32_t c1_entry_size = Util::ByteAlign(k) / 8;
 
         auto* c1_entry_bytes = new uint8_t[c1_entry_size];
-        safeSeek(disk_file, table_begin_pointers[8] + c1_index * Util::ByteAlign(k) / 8);
+        SafeSeek(disk_file, table_begin_pointers[8] + c1_index * Util::ByteAlign(k) / 8);
 
         uint64_t curr_f7 = c2_entry_f;
         uint64_t prev_f7 = c2_entry_f;
         broke = false;
         // Goes through C2 entries until we find the correct C1 checkpoint.
         for (uint64_t start = 0; start < kCheckpoint1Interval; start++) {
-            safeRead(disk_file, c1_entry_bytes, c1_entry_size);
+            SafeRead(disk_file, c1_entry_bytes, c1_entry_size);
             Bits c1_entry = Bits(c1_entry_bytes, Util::ByteAlign(k) / 8, Util::ByteAlign(k));
             uint64_t read_f7 = c1_entry.Slice(0, k).GetValue();
 
@@ -474,24 +468,24 @@ private:
         if (double_entry) {
             // In this case, we read the previous park as well as the current one
             c1_index -= 1;
-            safeSeek(disk_file, table_begin_pointers[8] + c1_index * Util::ByteAlign(k) / 8);
-            safeRead(disk_file, c1_entry_bytes, Util::ByteAlign(k) / 8);
+            SafeSeek(disk_file, table_begin_pointers[8] + c1_index * Util::ByteAlign(k) / 8);
+            SafeRead(disk_file, c1_entry_bytes, Util::ByteAlign(k) / 8);
             Bits c1_entry_bits = Bits(c1_entry_bytes, Util::ByteAlign(k) / 8, Util::ByteAlign(k));
             next_f7 = curr_f7;
             curr_f7 = c1_entry_bits.Slice(0, k).GetValue();
 
-            safeSeek(disk_file, table_begin_pointers[10] + c1_index * c3_entry_size);
+            SafeSeek(disk_file, table_begin_pointers[10] + c1_index * c3_entry_size);
 
-            safeRead(disk_file, encoded_size_buf, 2);
+            SafeRead(disk_file, encoded_size_buf, 2);
             encoded_size = Bits(encoded_size_buf, 2, 16).GetValue();
-            safeRead(disk_file, bit_mask, c3_entry_size - 2);
+            SafeRead(disk_file, bit_mask, c3_entry_size - 2);
 
             p7_positions =
                 GetP7Positions(curr_f7, f7, curr_p7_pos, bit_mask, encoded_size, c1_index);
 
-            safeRead(disk_file, encoded_size_buf, 2);
+            SafeRead(disk_file, encoded_size_buf, 2);
             encoded_size = Bits(encoded_size_buf, 2, 16).GetValue();
-            safeRead(disk_file, bit_mask, c3_entry_size - 2);
+            SafeRead(disk_file, bit_mask, c3_entry_size - 2);
 
             c1_index++;
             curr_p7_pos = c1_index * kCheckpoint1Interval;
@@ -501,10 +495,10 @@ private:
                 p7_positions.end(), second_positions.begin(), second_positions.end());
 
         } else {
-            safeSeek(disk_file, table_begin_pointers[10] + c1_index * c3_entry_size);
-            safeRead(disk_file, encoded_size_buf, 2);
+            SafeSeek(disk_file, table_begin_pointers[10] + c1_index * c3_entry_size);
+            SafeRead(disk_file, encoded_size_buf, 2);
             encoded_size = Bits(encoded_size_buf, 2, 16).GetValue();
-            safeRead(disk_file, bit_mask, c3_entry_size - 2);
+            SafeRead(disk_file, bit_mask, c3_entry_size - 2);
 
             p7_positions =
                 GetP7Positions(curr_f7, f7, curr_p7_pos, bit_mask, encoded_size, c1_index);
@@ -526,14 +520,14 @@ private:
         // P7.
         auto* p7_park_buf = new uint8_t[p7_park_size_bytes];
         uint64_t park_index = (p7_positions[0] == 0 ? 0 : p7_positions[0]) / kEntriesPerPark;
-        safeSeek(disk_file, table_begin_pointers[7] + park_index * p7_park_size_bytes);
-        safeRead(disk_file, p7_park_buf, p7_park_size_bytes);
+        SafeSeek(disk_file, table_begin_pointers[7] + park_index * p7_park_size_bytes);
+        SafeRead(disk_file, p7_park_buf, p7_park_size_bytes);
         ParkBits p7_park = ParkBits(p7_park_buf, p7_park_size_bytes, p7_park_size_bytes * 8);
         for (uint64_t i = 0; i < p7_positions[p7_positions.size() - 1] - p7_positions[0] + 1; i++) {
             uint64_t new_park_index = (p7_positions[i]) / kEntriesPerPark;
             if (new_park_index > park_index) {
-                safeSeek(disk_file, table_begin_pointers[7] + new_park_index * p7_park_size_bytes);
-                safeRead(disk_file, p7_park_buf, p7_park_size_bytes);
+                SafeSeek(disk_file, table_begin_pointers[7] + new_park_index * p7_park_size_bytes);
+                SafeRead(disk_file, p7_park_buf, p7_park_size_bytes);
                 p7_park = ParkBits(p7_park_buf, p7_park_size_bytes, p7_park_size_bytes * 8);
             }
             uint32_t start_bit_index = (p7_positions[i] % kEntriesPerPark) * (k + 1);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -20,7 +20,6 @@
 #include "../lib/include/picosha2.hpp"
 #include "calculate_bucket.hpp"
 #include "disk.hpp"
-#include "encoding.hpp"
 #include "plotter_disk.hpp"
 #include "prover_disk.hpp"
 #include "sort_manager.hpp"
@@ -931,12 +930,12 @@ TEST_CASE("FileDisk")
     write_disk_file(d);
 
     std::uint32_t val = 0;
-    for (int i = 0; i < num_test_entries; ++i) {
+    for (uint32_t i = 0; i < num_test_entries; ++i) {
         d.Read(i * 4, reinterpret_cast<std::uint8_t*>(&val), 4);
-        CHECK(i == val);
+        REQUIRE(i == val);
     }
 
-    for (int i = num_test_entries - 1; i > 0; --i) {
+    for (uint32_t i = num_test_entries - 1; i > 0; --i) {
         d.Read(i * 4, reinterpret_cast<std::uint8_t*>(&val), 4);
         CHECK(i == val);
     }
@@ -951,14 +950,14 @@ TEST_CASE("BufferedDisk")
 
     BufferedDisk bd(&d, num_test_entries * 4);
 
-    for (int i = 0; i < num_test_entries; ++i) {
+    for (uint32_t i = 0; i < num_test_entries; ++i) {
         auto const val = *reinterpret_cast<std::uint32_t const*>(bd.Read(i * 4, 4));
         CHECK(i == val);
     }
 
     // don't go all the way down to 0, every backwards read cursor movement will
     // print a warning
-    for (int i = num_test_entries - 1; i > num_test_entries / 2 + 200; --i) {
+    for (uint32_t i = num_test_entries - 1; i > num_test_entries / 2 + 200; --i) {
         auto const val = *reinterpret_cast<std::uint32_t const*>(bd.Read(i * 4, 4));
         CHECK(i == val);
     }
@@ -981,14 +980,14 @@ TEST_CASE("FilteredDisk")
         }
         FilteredDisk fd(std::move(bd), std::move(filter), 4);
 
-        for (int i = 0; i < num_test_entries / 2 - 1; ++i) {
+        for (uint32_t i = 0; i < num_test_entries / 2 - 1; ++i) {
             auto const val = *reinterpret_cast<std::uint32_t const*>(fd.Read(i * 4, 4));
             CHECK((i * 2) + 1 == val);
         }
 
         // don't go all the way down to 0, every backwards read cursor movement will
         // print a warning
-        for (int i = num_test_entries / 2 - 1; i > num_test_entries / 2 + 200; --i) {
+        for (uint32_t i = num_test_entries / 2 - 1; i > num_test_entries / 2 + 200; --i) {
             auto const val = *reinterpret_cast<std::uint32_t const*>(fd.Read(i * 4, 4));
             CHECK((i * 2) + 1 == val);
         }
@@ -1004,14 +1003,14 @@ TEST_CASE("FilteredDisk")
         }
         FilteredDisk fd(std::move(bd), std::move(filter), 4);
 
-        for (int i = 0; i < num_test_entries / 2 - 1; ++i) {
+        for (uint32_t i = 0; i < num_test_entries / 2 - 1; ++i) {
             auto const val = *reinterpret_cast<std::uint32_t const*>(fd.Read(i * 4, 4));
             CHECK((i * 2) == val);
         }
 
         // don't go all the way down to 0, every backwards read cursor movement will
         // print a warning
-        for (int i = num_test_entries / 2 - 1; i > num_test_entries / 2 + 200; --i) {
+        for (uint32_t i = num_test_entries / 2 - 1; i > num_test_entries / 2 + 200; --i) {
             auto const val = *reinterpret_cast<std::uint32_t const*>(fd.Read(i * 4, 4));
             CHECK((i * 2) == val);
         }

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -132,7 +132,7 @@ class TestPythonBindings(unittest.TestCase):
 
         pr = DiskProver(str(Path("myplotbad.dat")))
 
-        iterations: int = 5000000
+        iterations: int = 50000
         v = Verifier()
         successes = 0
         failures = 0

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -149,14 +149,13 @@ class TestPythonBindings(unittest.TestCase):
                     if computed_quality == quality:
                         successes += 1
                     else:
-                        print(f"Did not validate")
+                        print("Did not validate")
                         failures += 1
             except Exception as e:
                 print(f"Exception: {e}")
                 failures += 1
         print(f"Successes: {successes}")
         print(f"Failures: {failures}")
-
 
 
 if __name__ == "__main__":

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -6,7 +6,7 @@ from secrets import token_bytes
 
 
 class TestPythonBindings(unittest.TestCase):
-    def xtest_k_21(self):
+    def test_k_21(self):
         plot_seed: bytes = bytes(
             [
                 5,

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -2,12 +2,11 @@ import unittest
 from chiapos import DiskProver, DiskPlotter, Verifier
 from hashlib import sha256
 from pathlib import Path
+from secrets import token_bytes
 
 
 class TestPythonBindings(unittest.TestCase):
-    def test_k_21(self):
-        challenge: bytes = bytes([i for i in range(0, 32)])
-
+    def xtest_k_21(self):
         plot_seed: bytes = bytes(
             [
                 5,
@@ -99,7 +98,65 @@ class TestPythonBindings(unittest.TestCase):
             == "80e32f560f3a4347760d6baae8d16fbaf484948088bff05c51bdcc24b7bc40d9"
         )
         print(f"\nPlotfile asserted sha256: {plot_hash}\n")
-        Path("myplot.dat").unlink()
+
+    def test_faulty_plot_doesnt_crash(self):
+        if Path("myplot.dat").exists():
+            Path("myplot.dat").unlink()
+        if Path("myplotbad.dat").exists():
+            Path("myplotbad.dat").unlink()
+
+        plot_id: bytes = bytes([i for i in range(32, 64)])
+        pl = DiskPlotter()
+        pl.create_plot_disk(
+            ".",
+            ".",
+            ".",
+            "myplot.dat",
+            21,
+            bytes([1, 2, 3, 4, 5]),
+            plot_id,
+            300,
+            32,
+            8192,
+            8,
+            False,
+        )
+        f = open("myplot.dat", "rb")
+        all_data = bytearray(f.read())
+        f.close()
+        assert len(all_data) > 20000000
+        all_data_bad = all_data[:20000000] + bytearray(token_bytes(10000)) + all_data[20100000:]
+        f_bad = open("myplotbad.dat", "wb")
+        f_bad.write(all_data_bad)
+        f_bad.close()
+
+        pr = DiskProver(str(Path("myplotbad.dat")))
+
+        iterations: int = 5000000
+        v = Verifier()
+        successes = 0
+        failures = 0
+        for i in range(iterations):
+            if i % 100 == 0:
+                print(i)
+            challenge = sha256(i.to_bytes(4, "big")).digest()
+            try:
+                for index, quality in enumerate(pr.get_qualities_for_challenge(challenge)):
+                    proof = pr.get_full_proof(challenge, index)
+                    computed_quality = v.validate_proof(
+                        plot_id, pr.get_size(), challenge, proof
+                    )
+                    if computed_quality == quality:
+                        successes += 1
+                    else:
+                        print(f"Did not validate")
+                        failures += 1
+            except Exception as e:
+                print(f"Exception: {e}")
+                failures += 1
+        print(f"Successes: {successes}")
+        print(f"Failures: {failures}")
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I replicated segfaults on bad plots (scrambling or removing 0.5% of the plot for example).
In the cases of corrupted data (0.5% of the plot is randomly scrambled), the prover should still be able to return correct responses > 99% of the time, so this means faulty plots are still farmable. If the size of the plot is messed with, however, it wont be farmable, it will just throw (but no longer segfault). 


* Check that the stream is good right after seeking and reading. This prevents further issues down the line, by throwing immediately.
* When we read deltas size that are too large, throw immediately. The most common symptom of a bad plot is that the delta size is too large, which caused issues in decoding.  