### PR TITLE
code cleanup: remove useless code logic

### DIFF
--- a/src/phase4.hpp
+++ b/src/phase4.hpp
@@ -129,11 +129,7 @@ void RunPhase4(uint8_t k, uint8_t pos_size, FileDisk &tmp2_disk, Phase3Results &
             deltas_to_write.clear();
             ++num_C1_entries;
         } else {
-            if (entry_y == prev_y) {
-                deltas_to_write.push_back(0);
-            } else {
-                deltas_to_write.push_back(entry_y - prev_y);
-            }
+            deltas_to_write.push_back(entry_y - prev_y);
             prev_y = entry_y;
         }
         if (show_progress && f7_position % progress_update_increment == 0) {


### PR DESCRIPTION
Obviously, when `entry_y == prev_y`, the value of `entry_y - prev_y` will be zero.

And we can use:

```c++
            deltas_to_write.push_back(entry_y - prev_y);
```

instead of:

```c++
            if (entry_y == prev_y) {
                deltas_to_write.push_back(0);
            } else {
                deltas_to_write.push_back(entry_y - prev_y);
            }
```

Thanks for your review!