### PR TITLE
Reopen files upon read or write failure

### DIFF
--- a/src/disk.hpp
+++ b/src/disk.hpp
@@ -175,7 +175,11 @@ struct FileDisk {
                 std::cout << "Only read " << amtread << " of " << length << " bytes at offset "
                           << begin << " from " << filename_ << "with length " << writeMax
                           << ". Error " << ferror(f_) << ". Retrying in five minutes." << std::endl;
+                // Close, Reopen, and re-seek the file
+                Close();
+                bReading = false;
                 std::this_thread::sleep_for(5min);
+                Open(retryOpenFlag);
             }
         } while (amtread != length);
     }
@@ -208,7 +212,11 @@ struct FileDisk {
                 std::cout << "Only wrote " << amtwritten << " of " << length << " bytes at offset "
                           << begin << " to " << filename_ << "with length " << writeMax
                           << ". Error " << ferror(f_) << ". Retrying in five minutes." << std::endl;
+                // Close, Reopen, and re-seek the file
+                Close();
+                bReading = false;
                 std::this_thread::sleep_for(5min);
+                Open(writeFlag | retryOpenFlag);
             }
         } while (amtwritten != length);
     }

--- a/src/disk.hpp
+++ b/src/disk.hpp
@@ -175,7 +175,8 @@ struct FileDisk {
                 std::cout << "Only read " << amtread << " of " << length << " bytes at offset "
                           << begin << " from " << filename_ << "with length " << writeMax
                           << ". Error " << ferror(f_) << ". Retrying in five minutes." << std::endl;
-                // Close, Reopen, and re-seek the file
+                // Close, Reopen, and re-seek the file to recover in case the filesystem
+                // has been remounted.
                 Close();
                 bReading = false;
                 std::this_thread::sleep_for(5min);
@@ -212,7 +213,8 @@ struct FileDisk {
                 std::cout << "Only wrote " << amtwritten << " of " << length << " bytes at offset "
                           << begin << " to " << filename_ << "with length " << writeMax
                           << ". Error " << ferror(f_) << ". Retrying in five minutes." << std::endl;
-                // Close, Reopen, and re-seek the file
+                // Close, Reopen, and re-seek the file to recover in case the filesystem
+                // has been remounted.
                 Close();
                 bReading = false;
                 std::this_thread::sleep_for(5min);


### PR DESCRIPTION
If an attempt to read or write a temp file fails, close the
file before sleeping, then re-open it after sleeping.

This improves robustness when plotting with removable drives.
Previously, if a drive is unmounted/remounted during the plotting
process, the open files never recover and you get stuck in a loop
of:

`Only read 0 of <size> bytes at offset <offset> from "<filename>" with length <length>. Error 1. Retrying in five minutes.`

This change closes and re-opens files and can recover from (some?)
transient read and write problems. Specifically, if you have a
removable drive, and you unplug it during phase 2, it will recover
and continue when you plug the drive back in.