### PR TITLE
Add Process ID to log files

### DIFF
--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -164,6 +164,7 @@ public:
         std::cout << "Using " << num_buckets << " buckets" << std::endl;
         std::cout << "Using " << (int)num_threads << " threads of stripe size " << stripe_size
                   << std::endl;
+        std::cout << "Process ID is: " << ::getpid() << std::endl;
 
         // Cross platform way to concatenate paths, gulrak library.
         std::vector<fs::path> tmp_1_filenames = std::vector<fs::path>();


### PR DESCRIPTION
Motivation:

A user notices a plotting process fails to continue or that he configured it wrong while reading the logs or using a monitoring solution for plotting processes.
The user needs to find the plotting process that belongs to the log file.
Currently users try to match their configurations like the used temp drives, threads and bucket sizes from the log file to the command lines of running processes in Task Manager / System Viewer / HTOP so that they can kill the misbehaving process.
Having the Process ID as part of the log file greatly simplifies this process.