### PR TITLE
Fix infinite copy attempts when tmp and final dir are the same, but different

### DIFF
--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -168,17 +168,6 @@ public:
         // Cross platform way to concatenate paths, gulrak library.
         std::vector<fs::path> tmp_1_filenames = std::vector<fs::path>();
 
-        // The table0 file will be used for sort on disk spare. tables 1-7 are stored in their own
-        // file. Ensure all paths are canonical.
-        tmp_1_filenames.push_back(fs::path(tmp_dirname) / fs::path(filename + ".sort.tmp"));
-        for (size_t i = 1; i <= 7; i++) {
-            tmp_1_filenames.push_back(
-                fs::weakly_canonical(fs::path(tmp_dirname) / fs::path(filename + ".table" + std::to_string(i) + ".tmp")));
-        }
-        fs::path tmp_2_filename = fs::weakly_canonical(fs::path(tmp2_dirname) / fs::path(filename + ".2.tmp"));
-        fs::path final_2_filename = fs::weakly_canonical(fs::path(final_dirname) / fs::path(filename + ".2.tmp"));
-        fs::path final_filename = fs::weakly_canonical(fs::path(final_dirname) / fs::path(filename));
-
         // Check if the paths exist
         if (!fs::exists(tmp_dirname)) {
             throw InvalidValueException("Temp directory " + tmp_dirname + " does not exist");
@@ -191,6 +180,23 @@ public:
         if (!fs::exists(final_dirname)) {
             throw InvalidValueException("Final directory " + final_dirname + " does not exist");
         }
+        
+        // Ensure all paths are canonical.
+        fs::path tmp_dirname_canonical = fs::canonical(fs::path(tmp_dirname));
+        fs::path tmp2_dirname_canonical = fs::canonical(fs::path(tmp2_dirname));
+        fs::path final_dirname_canonical = fs::canonical(fs::path(final_dirname));
+
+        // The table0 file will be used for sort on disk spare. tables 1-7 are stored in their own
+        // file.
+        tmp_1_filenames.push_back(tmp_dirname_canonical / fs::path(filename + ".sort.tmp"));
+        for (size_t i = 1; i <= 7; i++) {
+            tmp_1_filenames.push_back(
+                tmp_dirname_canonical / fs::path(filename + ".table" + std::to_string(i) + ".tmp"));
+        }
+        fs::path tmp_2_filename = tmp2_dirname_canonical / fs::path(filename + ".2.tmp");
+        fs::path final_2_filename = final_dirname_canonical / fs::path(filename + ".2.tmp");
+        fs::path final_filename = final_dirname_canonical / fs::path(filename);
+
         for (fs::path& p : tmp_1_filenames) {
             fs::remove(p);
         }


### PR DESCRIPTION
See Chia-Network/chia-blockchain#5863

To elaborate on the title, when plotting and final and tmp2 dirs are the same canonically, but their paths are given differently (e.g. one expllicitly, the other as '.'), the code enters an infinite loop trying to copy `"./plot-k32-[...].plot.2.tmp" to "$PWD/plot-k32-[...].plot.2.tmp"` with an obvious error that the file exists.

In the issue above (in the chia-blockchain) I suggested that files should simply be renamed when both paths point to the same filesystem, but apparently `std::filesystem` doesn't expose `st_dev` field explicitly, so instead the code attempts to create a hard link and reverts back to copying when it fails (e.g. when the files reside on different filesystems, or the filesystem doesn't support hard links).

To summarize the changes:
* All dirnames are first canonicalized to ensure differently given paths to the same directory are treated correctly
* Before the final rename, the `.plot.2.tmp` file is first hardlinked from final dir to tmp2 dir. If the hard linking fails, the previous copy routine is used. Final rename requires either a successful copy or a hard link.

The code may still fail, if the tmp2 dir and final dir are essentially the same, but given through different canonical paths. An example of this happening is mounting the same block device under different mount points, e.g. mounting /dev/sda1 as `/mnt/plots` and `/mnt/tmp2`, and passing the mount points accordingly. The potential fixes for this are:
  * Always attempt to hardlink final plot to tmp2 plot before going the copy route; still requires care in case the hard link fails, but the directories are essentially the same;
  * Use `std::filesystem::equivalent` instead of comparing the parent paths;
  * Use pure `stat` syscall without the `std::filesystem` wrapper to compare `st_dev` of tmp2 and final dirs; if they match rename directly from tmp2 to final plot file, otherwise go safely the copy & rename route