### PR TITLE
Fix inverted bitfield flag in python bindings.

### DIFF
--- a/python-bindings/chiapos.cpp
+++ b/python-bindings/chiapos.cpp
@@ -68,7 +68,7 @@ PYBIND11_MODULE(chiapos, m)
                                       num_buckets,
                                       stripe_size,
                                       num_threads,
-                                      nobitfield);
+                                      nobitfield ? 0 : ENABLE_BITFIELD);
                 } catch (const std::exception &e) {
                     std::cout << "Caught plotting error: " << e.what() << std::endl;
                     throw e;


### PR DESCRIPTION
This is a fix for a bug that was introduced in a6fce5d485edb4b3b216389b203571392dccbff6.