### PR TITLE
Improved chacha8 performance with MSVC

### DIFF
--- a/src/chacha8.c
+++ b/src/chacha8.c
@@ -1,5 +1,12 @@
 #include "chacha8.h"
 
+#ifdef _MSC_VER
+
+#include <intrin.h>
+#include <string.h>
+
+#endif
+
 #define U32TO32_LITTLE(v) (v)
 #define U8TO32_LITTLE(p) (*(const uint32_t *)(p))
 #define U32TO8_LITTLE(p, v) (((uint32_t *)(p))[0] = U32TO32_LITTLE(v))
@@ -9,16 +16,6 @@
 #define XOR(v, w) ((v) ^ (w))
 #define PLUS(v, w) ((v) + (w))
 #define PLUSONE(v) (PLUS((v), 1))
-
-#define QUARTERROUND(a, b, c, d) \
-    a = PLUS(a, b);              \
-    d = ROTATE(XOR(d, a), 16);   \
-    c = PLUS(c, d);              \
-    b = ROTATE(XOR(b, c), 12);   \
-    a = PLUS(a, b);              \
-    d = ROTATE(XOR(d, a), 8);    \
-    c = PLUS(c, d);              \
-    b = ROTATE(XOR(b, c), 7)
 
 static const char sigma[16] = "expand 32-byte k";
 static const char tau[16] = "expand 16-byte k";
@@ -53,6 +50,90 @@ void chacha8_keysetup(struct chacha8_ctx *x, const uint8_t *k, uint32_t kbits, c
         x->input[15] = 0;
     }
 }
+
+#ifdef _MSC_VER
+
+typedef struct {
+    uint32_t a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p;
+} BLOCK;
+
+#define QROUND(a, b, c, d)       \
+    d = _rotl(d ^ (a += b), 16); \
+    b = _rotl(b ^ (c += d), 12); \
+    d = _rotl(d ^ (a += b), 8);  \
+    b = _rotl(b ^ (c += d), 7)
+#define FROUND                  \
+    QROUND(x.d, x.h, x.l, x.p); \
+    QROUND(x.c, x.g, x.k, x.o); \
+    QROUND(x.b, x.f, x.j, x.n); \
+    QROUND(x.a, x.e, x.i, x.m); \
+    QROUND(x.a, x.f, x.k, x.p); \
+    QROUND(x.b, x.g, x.l, x.m); \
+    QROUND(x.c, x.h, x.i, x.n); \
+    QROUND(x.d, x.e, x.j, x.o)
+#define FFINAL  \
+    x.a += j.a; \
+    x.b += j.b; \
+    x.c += j.c; \
+    x.d += j.d; \
+    x.e += j.e; \
+    x.f += j.f; \
+    x.g += j.g; \
+    x.h += j.h; \
+    x.i += j.i; \
+    x.j += j.j; \
+    x.k += j.k; \
+    x.l += j.l; \
+    x.m += j.m; \
+    x.n += j.n; \
+    x.o += j.o; \
+    x.p += j.p
+
+void chacha8_get_keystream(
+    const struct chacha8_ctx *ctx,
+    uint64_t pos,
+    uint32_t n_blocks,
+    uint8_t *c)
+{
+    BLOCK x;
+    BLOCK j;
+
+    if (!n_blocks)
+        return;
+
+    memcpy(&j, ctx, sizeof(BLOCK));
+    j.m = pos;
+    j.n = pos >> 32;
+
+_BLOCK_LOOP:
+
+    memcpy(&x, &j, sizeof(BLOCK));
+
+    FROUND;
+    FROUND;
+    FROUND;
+    FROUND;
+    FFINAL;
+
+    memcpy(c, &x, sizeof(BLOCK));
+
+    if (--n_blocks) {
+        c += 64, j.n += !++j.m;
+        goto _BLOCK_LOOP;
+    }
+}
+
+#else
+
+#define QUARTERROUND(a, b, c, d) \
+    a = PLUS(a, b);              \
+    d = ROTATE(XOR(d, a), 16);   \
+    c = PLUS(c, d);              \
+    b = ROTATE(XOR(b, c), 12);   \
+    a = PLUS(a, b);              \
+    d = ROTATE(XOR(d, a), 8);    \
+    c = PLUS(c, d);              \
+    b = ROTATE(XOR(b, c), 7)
 
 void chacha8_get_keystream(const struct chacha8_ctx *x, uint64_t pos, uint32_t n_blocks, uint8_t *c)
 {
@@ -147,3 +228,5 @@ void chacha8_get_keystream(const struct chacha8_ctx *x, uint64_t pos, uint32_t n
         c += 64;
     }
 }
+
+#endif

--- a/src/chacha8.c
+++ b/src/chacha8.c
@@ -1,10 +1,14 @@
 #include "chacha8.h"
 
-#ifdef _MSC_VER
-
-#include <intrin.h>
 #include <string.h>
-
+#if defined(_MSC_VER)
+#include <intrin.h>
+#elif defined(__GNUC__) && defined(__x86_64__)
+__inline static unsigned int __attribute__((__always_inline__, __artificial__, __gnu_inline__)) _rotl(unsigned int value, int count)
+{
+    // count &= 31;
+    return (value << count) | (value >> (-count & 31));
+}
 #endif
 
 #define U32TO32_LITTLE(v) (v)
@@ -51,7 +55,7 @@ void chacha8_keysetup(struct chacha8_ctx *x, const uint8_t *k, uint32_t kbits, c
     }
 }
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__GNUC__) && defined(__x86_64__)
 
 typedef struct {
     uint32_t a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p;


### PR DESCRIPTION
This improves the performance of chacha8 a little with MSVC. (around 23%)
Additional my test code and results with same compiler options:

```cpp
#include <chrono>
#include <vector>
#include <iostream>

#include "chacha8.h"

int main ()
{
	const uint32_t iteration = 100;
	const uint32_t blocks = 4096 * 128;

	std::vector<uint8_t> key;
	std::vector<uint8_t> iv;
	for (int i = 0; i < 32; ++i) key.push_back ((uint8_t)i);
	for (int i = 0; i < 8; ++i) iv.push_back ((uint8_t)i);

	std::vector<uint8_t> out1;
	std::vector<uint8_t> out2;
	out1.resize (blocks * 64);
	out2.resize (blocks * 64);

	chacha8_ctx ctx;
	chacha8_keysetup (&ctx, key.data (), 256, iv.data ());

	std::vector<double> res;
	for (auto i = 0; i < iteration; ++i)
	{
		auto start_org = std::chrono::steady_clock::now ();
		chacha8_get_keystream (&ctx, 0, blocks, out1.data ());
		auto end_org = std::chrono::steady_clock::now ();

		auto start_new = std::chrono::steady_clock::now ();
		chacha8_get_keystream_cst (&ctx, 0, blocks, out2.data ());
		auto end_new = std::chrono::steady_clock::now ();

		if (std::equal (out1.cbegin (), out1.cend (), out2.cbegin ()))
		{
			const auto r =
				(double)std::chrono::duration_cast<std::chrono::nanoseconds>(end_org - start_org).count () /
				(double)std::chrono::duration_cast<std::chrono::nanoseconds>(end_new - start_new).count ();
			res.push_back (r);
			std::cout << "org/new: " << r << std::endl;
		}
		else
			std::cout << "ERR" << std::endl;
	}

	auto avg = 0.0;
	for (auto& r : res) avg += r;
	std::cout << "org/new mean: " << avg / res.size () << std::endl;
}
```

```
... abbrev ...
org/new: 1.23318
org/new: 1.21971
org/new: 1.23604
org/new: 1.23034
org/new: 1.24382
org/new: 1.23477
org/new: 1.22043
org/new: 1.25348
org/new: 1.22831
org/new: 1.222
org/new: 1.25699
org/new: 1.23271
org/new: 1.23033
org/new: 1.2323
org/new: 1.22129
org/new: 1.68185
org/new: 1.25155
org/new: 0.963338
org/new: 1.40123
org/new: 1.2432
org/new mean: 1.23764
```

It has passed all tests. Thanks for your review.