### PR TITLE
Update plotter_disk.hpp

### DIFF
--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -179,6 +179,7 @@ public:
         }
         fs::path tmp_2_filename = fs::path(tmp2_dirname) / fs::path(filename + ".2.tmp");
         fs::path final_2_filename = fs::path(final_dirname) / fs::path(filename + ".2.tmp");
+        fs::path final_tmp_2_filename = fs::path(tmp2_dirname) / fs::path(filename);
         fs::path final_filename = fs::path(final_dirname) / fs::path(filename);
 
         // Check if the paths exist
@@ -382,34 +383,34 @@ public:
                               << final_filename << std::endl;
                 }
             } else {
-                if (!bCopied) {
-                    fs::copy(
-                        tmp_2_filename, final_2_filename, fs::copy_options::overwrite_existing, ec);
-                    if (ec.value() != 0) {
-                        std::cout << "Could not copy " << tmp_2_filename << " to "
-                                  << final_2_filename << ". Error " << ec.message()
-                                  << ". Retrying in five minutes." << std::endl;
-                    } else {
-                        std::cout << "Copied final file from " << tmp_2_filename << " to "
-                                  << final_2_filename << std::endl;
-                        copy.PrintElapsed("Copy time =");
-                        bCopied = true;
-
-                        bool removed_2 = fs::remove(tmp_2_filename);
-                        std::cout << "Removed temp2 file " << tmp_2_filename << "? " << removed_2
-                                  << std::endl;
-                    }
-                }
-                if (bCopied && (!bRenamed)) {
-                    fs::rename(final_2_filename, final_filename, ec);
+                if (!bRenamed) {
+                    fs::rename(tmp_2_filename, final_tmp_2_filename, ec);
                     if (ec.value() != 0) {
                         std::cout << "Could not rename " << tmp_2_filename << " to "
+                                  << final_tmp_2_filename << ". Error " << ec.message()
+                                  << ". Retrying in five minutes." << std::endl;
+                    } else {
+                        std::cout << "Renamed final file from " << tmp_2_filename << " to "
+                                  << final_tmp_2_filename << std::endl;
+                        bRenamed = true;
+                        if (!bCopied){
+                        fs::copy(
+                        final_tmp_2_filename, final_filename, fs::copy_options::overwrite_existing, ec);
+                    if (ec.value() != 0) {
+                        std::cout << "Could not copy " << final_tmp_2_filename << " to "
                                   << final_filename << ". Error " << ec.message()
                                   << ". Retrying in five minutes." << std::endl;
                     } else {
-                        std::cout << "Renamed final file from " << final_2_filename << " to "
+                        std::cout << "Copied final file from " << final_tmp_2_filename << " to "
                                   << final_filename << std::endl;
-                        bRenamed = true;
+                        copy.PrintElapsed("Copy time =");
+                        bCopied = true;
+
+                        bool removed_2 = fs::remove(final_tmp_2_filename);
+                        std::cout << "Removed temp2 file " << final_tmp_2_filename << "? " << removed_2
+                                  << std::endl;
+                         }
+                      }
                     }
                 }
             }


### PR DESCRIPTION
Hi,
This update is to help guys who're plotting/farming with S3 compatible storage to save unwanted deletion fess.
As S3 compatible storage does not support rename command, every time if you rename a file from the S3 destination, S3 will convert this command into copy the file into a new file and remove the old file, which costs additional deletion fees.

I just made a change to plotter_disk.hpp, it changes the temp file name to final name firstly in the local computer, then copy to the remote S3 compatible bucket, after that it removes the file from the local plotting machine.