### PR TITLE
Fix overflow in progress report

### DIFF
--- a/src/progress.hpp
+++ b/src/progress.hpp
@@ -3,7 +3,7 @@
 
 #include <iostream>
 
-void progress(int phase, int n, int max_n) {
+void progress(int phase, int64_t n, int64_t max_n) {
     float p = (100.0 / 4) * ((phase - 1.0) + (1.0 * n / max_n));
     std::cout << "Progress: " << p << std::endl;
 }


### PR DESCRIPTION
In phase4, the numerator `n` and denominator `max_n` reported via progress are larger than 2^31, causing the printed progress to be incorrect.
This change fixes that overflow.