### PR TITLE
Add parallel reads to GetQualitiesForChallenge

### DIFF
--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -206,6 +206,8 @@ public:
                     qualities.emplace_back(hash.data(), 32, 256);
                 }));
             }
+            // Waiting all read tasks finish
+            tasks[tasks.size() - 1].wait();
         }  // Scope for disk_file
         return qualities;
     }


### PR DESCRIPTION
Speed up quality check by parallel `GetQualitiesForChallenge` outer loop.
Especially help NFS drive. It is able to speed up 25% overall proofing time in my testing.