### PR TITLE
Add parallel reads to GetQualitiesForChallenge

### DIFF
--- a/src/disk.hpp
+++ b/src/disk.hpp
@@ -292,13 +292,14 @@ struct BufferedDisk : Disk
         }
         else {
             // ideally this won't happen
-            std::cout << "Disk read position regressed. It's optimized for forward scans. Performance may suffer\n"
+            /* std::cout << "Disk read position regressed. It's optimized for forward scans. "
+                            "Performance may suffer\n"
                 << "   read-offset: " << begin
                 << " read-length: " << length
                 << " file-size: " << file_size_
                 << " read-buffer: [" << read_buffer_start_ << ", " << read_buffer_size_ << "]"
                 << " file: " << disk_->GetFileName()
-                << '\n';
+                << '\n';*/
             static uint8_t temp[128];
             // all allocations need 7 bytes head-room, since
             // SliceInt64FromBytes() may overrun by 7 bytes

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -208,6 +208,7 @@ public:
             }
             // Waiting all read tasks finish
             tasks[p7_entries.size() - 1].wait();
+            delete [] tasks;
         }  // Scope for disk_file
         return qualities;
     }

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -167,33 +167,47 @@ public:
             // our two x values in the leaves.
             uint8_t last_5_bits = challenge[31] & 0x1f;
 
-            for (uint64_t position : p7_entries) {
-                // This inner loop goes from table 6 to table 1, getting the two backpointers,
-                // and following one of them.
-                for (uint8_t table_index = 6; table_index > 1; table_index--) {
-                    uint128_t line_point = ReadLinePoint(disk_file, table_index, position);
+            // Use tasks to make sure the order of "qualities" correct
+            auto tasks = new std::future<void>[p7_entries.size()];
+            for (int i = 0; i < p7_entries.size(); i++) {
+                tasks[i] = async(std::launch::async, [&, i] {
+                    uint64_t position = p7_entries[i];
+                    // Open the plot file for each task
+                    std::ifstream disk_file_(filename, std::ios::in | std::ios::binary);
+                    // This inner loop goes from table 6 to table 1, getting the two backpointers,
+                    // and following one of them.
+                    for (uint8_t table_index = 6; table_index > 1; table_index--) {
+                        uint128_t line_point = ReadLinePoint(disk_file_, table_index, position);
 
-                    auto xy = Encoding::LinePointToSquare(line_point);
-                    assert(xy.first >= xy.second);
+                        auto xy = Encoding::LinePointToSquare(line_point);
+                        assert(xy.first >= xy.second);
 
-                    if (((last_5_bits >> (table_index - 2)) & 1) == 0) {
-                        position = xy.second;
-                    } else {
-                        position = xy.first;
+                        if (((last_5_bits >> (table_index - 2)) & 1) == 0) {
+                            position = xy.second;
+                        } else {
+                            position = xy.first;
+                        }
                     }
-                }
-                uint128_t new_line_point = ReadLinePoint(disk_file, 1, position);
-                auto x1x2 = Encoding::LinePointToSquare(new_line_point);
+                    uint128_t new_line_point = ReadLinePoint(disk_file_, 1, position);
+                    auto x1x2 = Encoding::LinePointToSquare(new_line_point);
 
-                // The final two x values (which are stored in the same location) are hashed
-                std::vector<unsigned char> hash_input(32 + Util::ByteAlign(2 * k) / 8, 0);
-                memcpy(hash_input.data(), challenge, 32);
-                (LargeBits(x1x2.second, k) + LargeBits(x1x2.first, k))
-                    .ToBytes(hash_input.data() + 32);
-                std::vector<unsigned char> hash(picosha2::k_digest_size);
-                picosha2::hash256(hash_input.begin(), hash_input.end(), hash.begin(), hash.end());
-                qualities.emplace_back(hash.data(), 32, 256);
+                    // The final two x values (which are stored in the same location) are hashed
+                    std::vector<unsigned char> hash_input(32 + Util::ByteAlign(2 * k) / 8, 0);
+                    memcpy(hash_input.data(), challenge, 32);
+                    (LargeBits(x1x2.second, k) + LargeBits(x1x2.first, k))
+                        .ToBytes(hash_input.data() + 32);
+                    std::vector<unsigned char> hash(picosha2::k_digest_size);
+                    picosha2::hash256(
+                        hash_input.begin(), hash_input.end(), hash.begin(), hash.end());
+                    // Wait for previous appending finish, order matters
+                    if (i > 0) {
+                        tasks[i - 1].wait();
+                    }
+                    qualities.emplace_back(hash.data(), 32, 256);
+                });
             }
+            // Waiting all read tasks finish
+            tasks[p7_entries.size() - 1].wait();
         }  // Scope for disk_file
         return qualities;
     }


### PR DESCRIPTION
Add parallel reads to GetQualitiesForChallenge
Ignore "Disk read position regressed" warning, it will be always in this case if read file is in parallel

This time it should pass all the tests. It is so strange that it works in Windows but not Unix-type systems previously. I fixed it anyway.