### PR TITLE
Removes redundant booleans

### DIFF
--- a/uint128_t/uint128_t.cpp
+++ b/uint128_t/uint128_t.cpp
@@ -157,7 +157,7 @@ uint128_t uint128_t::operator<<(const uint128_t & rhs) const{
     else if (shift < 64){
         return uint128_t((UPPER << shift) + (LOWER >> (64 - shift)), LOWER << shift);
     }
-    else if ((128 > shift) && (shift > 64)){
+    else if (shift > 64) {
         return uint128_t(LOWER << (shift - 64), 0);
     }
     else{
@@ -184,7 +184,7 @@ uint128_t uint128_t::operator>>(const uint128_t & rhs) const{
     else if (shift < 64){
         return uint128_t(UPPER >> shift, (UPPER << (64 - shift)) + (LOWER >> shift));
     }
-    else if ((128 > shift) && (shift > 64)){
+    else if (shift > 64) {
         return uint128_t(0, (UPPER >> (shift - 64)));
     }
     else{


### PR DESCRIPTION
After the if clause (shift >= 128) fails, it is ensured that shift is less than 128 when it goes through that part of the code, hence (128 > shift) is the same as (shift < 128) which is always true. Therefore it can be removed from both clauses.