### PR TITLE
python-bindings|prover_disk|tests: Add `pickle` support for `DiskProver`

### DIFF
--- a/python-bindings/chiapos.cpp
+++ b/python-bindings/chiapos.cpp
@@ -78,6 +78,28 @@ PYBIND11_MODULE(chiapos, m)
     py::class_<DiskProver>(m, "DiskProver")
         .def(py::init<const std::string &>())
         .def("is_valid", [](const DiskProver &dp) { return dp.IsValid(); })
+        .def(py::pickle(
+            [](const DiskProver& dp) { // __getstate__
+                return py::make_tuple(dp.GetFilename(),
+                                      dp.GetSize(),
+                                      dp.GetMemo(),
+                                      dp.GetId(),
+                                      dp.GetTableBeginPointers(),
+                                      dp.GetC2());
+                },
+            [](const py::tuple& t) { // __setstate__
+                if (t.size() != 6)
+                    throw std::runtime_error("Invalid state!");
+
+                auto filename = t[0].cast<std::string>();
+                auto k = t[1].cast<uint8_t>();
+                auto memo = t[2].cast<std::vector<uint8_t>>();
+                auto id = t[3].cast<std::vector<uint8_t>>();
+                auto table_begin_pointers = t[4].cast<std::vector<uint64_t>>();
+                auto C2 = t[5].cast<std::vector<uint64_t>>();
+                return DiskProver(filename, memo, id, k,
+                                  table_begin_pointers, C2);
+            }))
         .def(
             "get_memo",
             [](DiskProver &dp) {

--- a/python-bindings/chiapos.cpp
+++ b/python-bindings/chiapos.cpp
@@ -77,6 +77,7 @@ PYBIND11_MODULE(chiapos, m)
 
     py::class_<DiskProver>(m, "DiskProver")
         .def(py::init<const std::string &>())
+        .def("is_valid", [](const DiskProver &dp) { return dp.IsValid(); })
         .def(
             "get_memo",
             [](DiskProver &dp) {

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -78,7 +78,7 @@ public:
         if (this->table_begin_pointers.size() != table_begin_pointers_size) {
             throw std::invalid_argument("Invalid table_begin_pointers size: " + std::to_string(this->table_begin_pointers.size()));
         }
-        uint32_t expected_size = ((this->table_begin_pointers[10] - this->table_begin_pointers[9]) / (Util::ByteAlign(k) / 8)) - 1;
+        const uint32_t expected_size = ((this->table_begin_pointers[10] - this->table_begin_pointers[9]) / (Util::ByteAlign(k) / 8)) - 1;
         if (this->C2.size() != expected_size) {
             throw std::invalid_argument("Invalid C2 size: " + std::to_string(this->C2.size()));
         }

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -47,7 +47,7 @@ struct plot_header {
 // The DiskProver, given a correctly formatted plot file, can efficiently generate valid proofs
 // of space, for a given challenge.
 class DiskProver {
-    const size_t table_begin_pointers_size{11};
+    static const size_t table_begin_pointers_size{11};
 public:
     // The constructor opens the file, and reads the contents of the file header. The table pointers
     // will be used to find and seek to all seven tables, at the time of proving.

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -47,7 +47,7 @@ struct plot_header {
 // The DiskProver, given a correctly formatted plot file, can efficiently generate valid proofs
 // of space, for a given challenge.
 class DiskProver {
-    const size_t nTableBeginPointerCount{11};
+    const size_t table_begin_pointers_size{11};
 public:
     // The constructor opens the file, and reads the contents of the file header. The table pointers
     // will be used to find and seek to all seven tables, at the time of proving.
@@ -75,11 +75,11 @@ public:
         if (k < kMinPlotSize || k > kMaxPlotSize) {
             throw std::invalid_argument("Invalid k: " + std::to_string(k));
         }
-        if (this->table_begin_pointers.size() != nTableBeginPointerCount) {
+        if (this->table_begin_pointers.size() != table_begin_pointers_size) {
             throw std::invalid_argument("Invalid table_begin_pointers size: " + std::to_string(this->table_begin_pointers.size()));
         }
-        uint32_t nExpectedSize = ((this->table_begin_pointers[10] - this->table_begin_pointers[9]) / (Util::ByteAlign(k) / 8)) - 1;
-        if (this->C2.size() != nExpectedSize) {
+        uint32_t expected_size = ((this->table_begin_pointers[10] - this->table_begin_pointers[9]) / (Util::ByteAlign(k) / 8)) - 1;
+        if (this->C2.size() != expected_size) {
             throw std::invalid_argument("Invalid C2 size: " + std::to_string(this->C2.size()));
         }
     }
@@ -297,11 +297,11 @@ private:
         memo_in.resize(Util::TwoBytesToInt(size_buf));
         SafeRead(disk_file, memo_in.data(), memo_in.size());
 
-        table_begin_pointers_in = std::vector<uint64_t>(nTableBeginPointerCount, 0);
+        table_begin_pointers_in = std::vector<uint64_t>(table_begin_pointers_size, 0);
         C2_in = std::vector<uint64_t>();
 
         uint8_t pointer_buf[8];
-        for (size_t i = 1; i < nTableBeginPointerCount; i++) {
+        for (size_t i = 1; i < table_begin_pointers_size; i++) {
             SafeRead(disk_file, pointer_buf, 8);
             table_begin_pointers_in[i] = Util::EightBytesToInt(pointer_buf);
         }

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -53,73 +53,13 @@ public:
     // will be used to find and seek to all seven tables, at the time of proving.
     explicit DiskProver(const std::string& filename) : id(kIdLen)
     {
-        struct plot_header header{};
         this->filename = filename;
-
-        std::ifstream disk_file(filename, std::ios::in | std::ios::binary);
-
-        if (!disk_file.is_open()) {
-            throw std::invalid_argument("Invalid file " + filename);
-        }
-        // 19 bytes  - "Proof of Space Plot" (utf-8)
-        // 32 bytes  - unique plot id
-        // 1 byte    - k
-        // 2 bytes   - format description length
-        // x bytes   - format description
-        // 2 bytes   - memo length
-        // x bytes   - memo
-
-        SafeRead(disk_file, (uint8_t*)&header, sizeof(header));
-        if (memcmp(header.magic, "Proof of Space Plot", sizeof(header.magic)) != 0)
-            throw std::invalid_argument("Invalid plot header magic");
-
-        uint16_t fmt_desc_len = Util::TwoBytesToInt(header.fmt_desc_len);
-
-        if (fmt_desc_len == kFormatDescription.size() &&
-            !memcmp(header.fmt_desc, kFormatDescription.c_str(), fmt_desc_len)) {
-            // OK
-        } else {
-            throw std::invalid_argument("Invalid plot file format");
-        }
-        memcpy(id.data(), header.id, sizeof(header.id));
-        this->k = header.k;
-        SafeSeek(disk_file, offsetof(struct plot_header, fmt_desc) + fmt_desc_len);
-
-        uint8_t size_buf[2];
-        SafeRead(disk_file, size_buf, 2);
-        memo.resize(Util::TwoBytesToInt(size_buf));
-        SafeRead(disk_file, memo.data(), memo.size());
-
-        this->table_begin_pointers = std::vector<uint64_t>(nTableBeginPointerCount, 0);
-        this->C2 = std::vector<uint64_t>();
-
-        uint8_t pointer_buf[8];
-        for (size_t i = 1; i < nTableBeginPointerCount; i++) {
-            SafeRead(disk_file, pointer_buf, 8);
-            this->table_begin_pointers[i] = Util::EightBytesToInt(pointer_buf);
-        }
-
-        SafeSeek(disk_file, table_begin_pointers[9]);
-
-        uint8_t c2_size = (Util::ByteAlign(k) / 8);
-        uint32_t c2_entries = (table_begin_pointers[10] - table_begin_pointers[9]) / c2_size;
-        if (c2_entries == 0 || c2_entries == 1) {
-            throw std::invalid_argument("Invalid C2 table size");
-        }
-
-        // The list of C2 entries is small enough to keep in memory. When proving, we can
-        // read from disk the C1 and C3 entries.
-        auto* c2_buf = new uint8_t[c2_size];
-        for (uint32_t i = 0; i < c2_entries - 1; i++) {
-            SafeRead(disk_file, c2_buf, c2_size);
-            this->C2.push_back(Bits(c2_buf, c2_size, c2_size * 8).Slice(0, k).GetValue());
-        }
-
-        delete[] c2_buf;
+        Read(id, memo, k, table_begin_pointers, C2);
     }
 
     // Note: This constructor presumes the input parameter are valid for the provided file and does
-    // not validate the file itself.
+    // not validate the file itself. It's recommended to use `IsValid` after construction to make
+    // sure the given file matches expectations.
     DiskProver(std::string filename, std::vector<uint8_t> memo, std::vector<uint8_t> id, uint8_t k,
                std::vector<uint64_t> table_begin_pointers, std::vector<uint64_t> C2) :
         filename(std::move(filename)),
@@ -175,6 +115,39 @@ public:
     const std::string& GetFilename() const noexcept { return filename; }
 
     uint8_t GetSize() const noexcept { return k; }
+
+    void Validate() const
+    {
+        uint8_t k_out;
+        std::vector<uint8_t> id_out, memo_out;
+        std::vector<uint64_t> table_begin_pointers_out, C2_out;
+        Read(id_out, memo_out, k_out, table_begin_pointers_out, C2_out);
+        if (id != id_out) {
+            throw std::invalid_argument("EnsureValid: Invalid id");
+        }
+        if (memo != memo_out) {
+            throw std::invalid_argument("EnsureValid: Invalid memo");
+        }
+        if (k != k_out) {
+            throw std::invalid_argument("EnsureValid: Invalid k");
+        }
+        if (table_begin_pointers != table_begin_pointers_out) {
+            throw std::invalid_argument("EnsureValid: Invalid table_begin_pointers");
+        }
+        if (C2 != C2_out) {
+            throw std::invalid_argument("EnsureValid: Invalid C2");
+        }
+    }
+
+    bool IsValid() const
+    {
+        try {
+            Validate();
+        } catch (...) {
+            return false;
+        }
+        return true;
+    }
 
     // Given a challenge, returns a quality string, which is sha256(challenge + 2 adjecent x
     // values), from the 64 value proof. Note that this is more efficient than fetching all 64 x
@@ -280,9 +253,77 @@ private:
     std::string filename;
     std::vector<uint8_t> memo;
     std::vector<uint8_t> id;  // Unique plot id
-    uint8_t k;
+    uint8_t k{0};
     std::vector<uint64_t> table_begin_pointers;
     std::vector<uint64_t> C2;
+
+    void Read(std::vector<uint8_t>& id_in, std::vector<uint8_t>& memo_in, uint8_t& k_in, std::vector<uint64_t>& table_begin_pointers_in, std::vector<uint64_t>& C2_in) const
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+
+        std::ifstream disk_file(filename, std::ios::in | std::ios::binary);
+
+        if (!disk_file.is_open()) {
+            throw std::invalid_argument("Invalid file " + filename);
+        }
+        struct plot_header header{};
+        // 19 bytes  - "Proof of Space Plot" (utf-8)
+        // 32 bytes  - unique plot id
+        // 1 byte    - k
+        // 2 bytes   - format description length
+        // x bytes   - format description
+        // 2 bytes   - memo length
+        // x bytes   - memo
+
+        SafeRead(disk_file, (uint8_t*)&header, sizeof(header));
+        if (memcmp(header.magic, "Proof of Space Plot", sizeof(header.magic)) != 0)
+            throw std::invalid_argument("Invalid plot header magic");
+
+        uint16_t fmt_desc_len = Util::TwoBytesToInt(header.fmt_desc_len);
+
+        if (fmt_desc_len == kFormatDescription.size() &&
+        !memcmp(header.fmt_desc, kFormatDescription.c_str(), fmt_desc_len)) {
+            // OK
+        } else {
+            throw std::invalid_argument("Invalid plot file format");
+        }
+        id_in = std::vector<uint8_t>(kIdLen);
+        memcpy(id_in.data(), header.id, sizeof(header.id));
+        k_in = header.k;
+        SafeSeek(disk_file, offsetof(struct plot_header, fmt_desc) + fmt_desc_len);
+
+        uint8_t size_buf[2];
+        SafeRead(disk_file, size_buf, 2);
+        memo_in.resize(Util::TwoBytesToInt(size_buf));
+        SafeRead(disk_file, memo_in.data(), memo_in.size());
+
+        table_begin_pointers_in = std::vector<uint64_t>(nTableBeginPointerCount, 0);
+        C2_in = std::vector<uint64_t>();
+
+        uint8_t pointer_buf[8];
+        for (size_t i = 1; i < nTableBeginPointerCount; i++) {
+            SafeRead(disk_file, pointer_buf, 8);
+            table_begin_pointers_in[i] = Util::EightBytesToInt(pointer_buf);
+        }
+
+        SafeSeek(disk_file, table_begin_pointers_in[9]);
+
+        uint8_t c2_size = (Util::ByteAlign(k_in) / 8);
+        uint32_t c2_entries = (table_begin_pointers_in[10] - table_begin_pointers_in[9]) / c2_size;
+        if (c2_entries == 0 || c2_entries == 1) {
+            throw std::invalid_argument("Invalid C2 table size");
+        }
+
+        // The list of C2 entries is small enough to keep in memory. When proving, we can
+        // read from disk the C1 and C3 entries.
+        auto* c2_buf = new uint8_t[c2_size];
+        for (uint32_t i = 0; i < c2_entries - 1; i++) {
+            SafeRead(disk_file, c2_buf, c2_size);
+            C2_in.push_back(Bits(c2_buf, c2_size, c2_size * 8).Slice(0, k).GetValue());
+        }
+
+        delete[] c2_buf;
+    }
 
     // Using this method instead of simply seeking will prevent segfaults that would arise when
     // continuing the process of looking up qualities.

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -144,6 +144,17 @@ public:
         }
     }
 
+    DiskProver(DiskProver&& other) noexcept
+    {
+        std::lock_guard<std::mutex> lock(other._mtx);
+        filename = std::move(other.filename);
+        memo = std::move(other.memo);
+        id = std::move(other.id);
+        k = other.k;
+        table_begin_pointers = std::move(other.table_begin_pointers);
+        C2 = std::move(other.C2);
+    }
+
     ~DiskProver()
     {
         std::lock_guard<std::mutex> l(_mtx);
@@ -161,7 +172,7 @@ public:
 
     const std::vector<uint64_t>& GetC2() const noexcept { return C2; }
 
-    std::string GetFilename() const noexcept { return filename; }
+    const std::string& GetFilename() const noexcept { return filename; }
 
     uint8_t GetSize() const noexcept { return k; }
 

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -104,9 +104,9 @@ public:
         Encoding::ANSFree(kC3R);
     }
 
-    const std::vector<uint8_t>& GetMemo() { return memo; }
+    const std::vector<uint8_t>& GetMemo() const { return memo; }
 
-    const std::vector<uint8_t>& GetId() { return id; }
+    const std::vector<uint8_t>& GetId() const { return id; }
     
     const std::vector<uint64_t>& GetTableBeginPointers() const noexcept { return table_begin_pointers; }
 

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -118,6 +118,32 @@ public:
         delete[] c2_buf;
     }
 
+    // Note: This constructor presumes the input parameter are valid for the provided file and does
+    // not validate the file itself.
+    DiskProver(std::string filename, std::vector<uint8_t> memo, std::vector<uint8_t> id, uint8_t k,
+               std::vector<uint64_t> table_begin_pointers, std::vector<uint64_t> C2) :
+        filename(std::move(filename)),
+        memo(std::move(memo)),
+        id(std::move(id)),
+        k(k),
+        table_begin_pointers(std::move(table_begin_pointers)),
+        C2(std::move(C2))
+    {
+        if (this->id.size() != kIdLen) {
+            throw std::invalid_argument("Invalid id size: " + std::to_string(this->id.size()));
+        }
+        if (k < kMinPlotSize || k > kMaxPlotSize) {
+            throw std::invalid_argument("Invalid k: " + std::to_string(k));
+        }
+        if (this->table_begin_pointers.size() != nTableBeginPointerCount) {
+            throw std::invalid_argument("Invalid table_begin_pointers size: " + std::to_string(this->table_begin_pointers.size()));
+        }
+        uint32_t nExpectedSize = ((this->table_begin_pointers[10] - this->table_begin_pointers[9]) / (Util::ByteAlign(k) / 8)) - 1;
+        if (this->C2.size() != nExpectedSize) {
+            throw std::invalid_argument("Invalid C2 size: " + std::to_string(this->C2.size()));
+        }
+    }
+
     ~DiskProver()
     {
         std::lock_guard<std::mutex> l(_mtx);
@@ -130,6 +156,10 @@ public:
     const std::vector<uint8_t>& GetMemo() { return memo; }
 
     const std::vector<uint8_t>& GetId() { return id; }
+    
+    const std::vector<uint64_t>& GetTableBeginPointers() const noexcept { return table_begin_pointers; }
+
+    const std::vector<uint64_t>& GetC2() const noexcept { return C2; }
 
     std::string GetFilename() const noexcept { return filename; }
 

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -47,6 +47,7 @@ struct plot_header {
 // The DiskProver, given a correctly formatted plot file, can efficiently generate valid proofs
 // of space, for a given challenge.
 class DiskProver {
+    const size_t nTableBeginPointerCount{11};
 public:
     // The constructor opens the file, and reads the contents of the file header. The table pointers
     // will be used to find and seek to all seven tables, at the time of proving.
@@ -89,11 +90,11 @@ public:
         memo.resize(Util::TwoBytesToInt(size_buf));
         SafeRead(disk_file, memo.data(), memo.size());
 
-        this->table_begin_pointers = std::vector<uint64_t>(11, 0);
+        this->table_begin_pointers = std::vector<uint64_t>(nTableBeginPointerCount, 0);
         this->C2 = std::vector<uint64_t>();
 
         uint8_t pointer_buf[8];
-        for (uint8_t i = 1; i < 11; i++) {
+        for (size_t i = 1; i < nTableBeginPointerCount; i++) {
             SafeRead(disk_file, pointer_buf, 8);
             this->table_begin_pointers[i] = Util::EightBytesToInt(pointer_buf);
         }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1087,5 +1087,24 @@ TEST_CASE("DiskProver")
         invalid_c2.push_back(p1_C2.back());
         REQUIRE_THROWS(DiskProver(p1_filename, p1_memo, p1_id, p1_k, p1_pointers, invalid_c2));
         REQUIRE(remove(filename.c_str()) == 0);
+        // Test move constructor
+        auto* p1_filename_ptr = prover1.GetFilename().data();
+        auto* p1_memo_ptr = prover1.GetMemo().data();
+        auto* p1_id_ptr = prover1.GetId().data();
+        auto* p1_table_begin_pointers_ptr = prover1.GetTableBeginPointers().data();
+        auto* p1_C2_ptr = prover1.GetC2().data();
+        DiskProver prover3(std::move(prover1));
+        REQUIRE(prover3.GetFilename().data() == p1_filename_ptr);
+        REQUIRE(prover3.GetMemo().data() == p1_memo_ptr);
+        REQUIRE(prover3.GetId().data() == p1_id_ptr);
+        REQUIRE(prover3.GetTableBeginPointers().data() == p1_table_begin_pointers_ptr);
+        REQUIRE(prover3.GetC2().data() == p1_C2_ptr);
+        REQUIRE(prover1.GetFilename().empty());
+        REQUIRE(prover1.GetMemo().empty());
+        REQUIRE(prover1.GetId().empty());
+        REQUIRE(prover1.GetSize() == prover1.GetSize());
+        REQUIRE(prover1.GetTableBeginPointers().empty());
+        REQUIRE(prover1.GetC2().empty());
+        REQUIRE(!prover1.IsValid());
     }
 }

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -1,4 +1,6 @@
 import unittest
+import pickle
+
 from chiapos import DiskProver, DiskPlotter, Verifier
 from hashlib import sha256
 from pathlib import Path
@@ -176,6 +178,36 @@ class TestPythonBindings(unittest.TestCase):
                 failures += 1
         print(f"Successes: {successes}")
         print(f"Failures: {failures}")
+
+    def test_pickle_support(self):
+        if not Path("test_plot.dat").exists():
+            plot_id: bytes = bytes([i for i in range(0, 32)])
+            pl = DiskPlotter()
+            pl.create_plot_disk(
+                ".",
+                ".",
+                ".",
+                "test_plot.dat",
+                21,
+                bytes([1, 2, 3, 4, 5]),
+                plot_id,
+                300,
+                32,
+                8192,
+                8,
+                False,
+            )
+
+        prover1: DiskProver = DiskProver(str(Path("test_plot.dat")))
+        data = pickle.dumps(prover1)
+        prover_recovered: DiskProver = pickle.loads(data)
+        assert prover1.get_size() == prover_recovered.get_size()
+        assert prover1.get_filename() == prover_recovered.get_filename()
+        assert prover1.get_id() == prover_recovered.get_id()
+        assert prover1.get_memo() == prover_recovered.get_memo()
+        Path("test_plot.dat").unlink()
+        prover_recovered_invalid: DiskProver = pickle.loads(data)
+        assert not prover_recovered_invalid.is_valid()
 
 
 if __name__ == "__main__":

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -62,6 +62,7 @@ class TestPythonBindings(unittest.TestCase):
         pl = None
 
         pr = DiskProver(str(Path("myplot.dat")))
+        assert pr.is_valid()
 
         total_proofs: int = 0
         total_proofs2: int = 0


### PR DESCRIPTION
This is needed for plots caching in `chia-blockchain`.

Based on #302