### PR TITLE
Add buffer size checks that fail if encoded_size is greater than the …

### DIFF
--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -490,6 +490,13 @@ private:
 
             SafeRead(disk_file, encoded_size_buf, 2);
             encoded_size = Bits(encoded_size_buf, 2, 16).GetValue();
+
+            // Avoid telling GetP7Positions and functions it uses that we have more
+            // bytes than we allocated for bit_mask above.
+            if (encoded_size > c3_entry_size - 2) {
+                return std::vector<uint64_t>();
+            }
+
             SafeRead(disk_file, bit_mask, c3_entry_size - 2);
 
             p7_positions =
@@ -497,12 +504,20 @@ private:
 
             SafeRead(disk_file, encoded_size_buf, 2);
             encoded_size = Bits(encoded_size_buf, 2, 16).GetValue();
+
+            // Avoid telling GetP7Positions and functions it uses that we have more
+            // bytes than we allocated for bit_mask above.
+            if (encoded_size > c3_entry_size - 2) {
+                return std::vector<uint64_t>();
+            }
+
             SafeRead(disk_file, bit_mask, c3_entry_size - 2);
 
             c1_index++;
             curr_p7_pos = c1_index * kCheckpoint1Interval;
             auto second_positions =
                 GetP7Positions(next_f7, f7, curr_p7_pos, bit_mask, encoded_size, c1_index);
+
             p7_positions.insert(
                 p7_positions.end(), second_positions.begin(), second_positions.end());
 
@@ -510,6 +525,13 @@ private:
             SafeSeek(disk_file, table_begin_pointers[10] + c1_index * c3_entry_size);
             SafeRead(disk_file, encoded_size_buf, 2);
             encoded_size = Bits(encoded_size_buf, 2, 16).GetValue();
+
+            // Avoid telling GetP7Positions and functions it uses that we have more
+            // bytes than we allocated for bit_mask above.
+            if (encoded_size > c3_entry_size - 2) {
+                return std::vector<uint64_t>();
+            }
+
             SafeRead(disk_file, bit_mask, c3_entry_size - 2);
 
             p7_positions =


### PR DESCRIPTION
…amount read from disk, c3_entry_size - 2

Admittedly I'm not familiar with this code, and this is a deduction from looking at the crash https://github.com/Chia-Network/chia-blockchain/issues/8303.  My hypothesis is that the crash, which occurs at a movzbl instruction which i believe is reading a byte from cSrc in FSE_decompress_usingDTable_generic.