### PR TITLE
FxCalculator global init fix for race condition

### DIFF
--- a/src/calculate_bucket.hpp
+++ b/src/calculate_bucket.hpp
@@ -209,8 +209,8 @@ public:
 
         this->rmap.resize(kBC);
         if (!initialized) {
-            initialized = true;
             load_tables();
+            initialized = true;
         }
     }
 


### PR DESCRIPTION
When `Verifier::ValidateProof` is called at the same time from multiple threads some will fail due to the global lookup table not being setup yet. Hence why the flag should be set after the table is created. 
Now it can happen that multiple threads will setup the table in parallel, but that's fine since the output is the same.