### PR TITLE
plotter_disk: Keep streams syncronized and `std::cin` tied

### DIFF
--- a/src/plotter_disk.hpp
+++ b/src/plotter_disk.hpp
@@ -199,9 +199,6 @@ public:
         fs::remove(tmp_2_filename);
         fs::remove(final_filename);
 
-        std::ios_base::sync_with_stdio(false);
-        std::ostream* prevstr = std::cin.tie(NULL);
-
         {
             // Scope for FileDisk
             std::vector<FileDisk> tmp_1_disks;
@@ -357,9 +354,6 @@ public:
                       << " GiB" << std::endl;
             all_phases.PrintElapsed("Total time =");
         }
-
-        std::cin.tie(prevstr);
-        std::ios_base::sync_with_stdio(true);
 
         for (fs::path p : tmp_1_filenames) {
             fs::remove(p);


### PR DESCRIPTION
I think we should drop it since it doesn't bring any value (at least from my understanding) but it messes with the test overview window in CLion. You can run the tests without this PR and as soon as a test created a plot it just doesn't show the result of this and the following tests, instead it shows a endless spinner.