### PR TITLE
src|tests|python-bindings: Make `DiskProver`(de)serializable

### DIFF
--- a/python-bindings/chiapos.cpp
+++ b/python-bindings/chiapos.cpp
@@ -77,6 +77,16 @@ PYBIND11_MODULE(chiapos, m)
 
     py::class_<DiskProver>(m, "DiskProver")
         .def(py::init<const std::string &>())
+        .def_static("from_bytes", [](const py::bytes &bytes) -> DiskProver {
+            py::buffer_info info(py::buffer(bytes).request());
+            auto data = reinterpret_cast<const uint8_t*>(info.ptr);
+            auto vecBytes = std::vector<uint8_t>(data, data + info.size);
+            return DiskProver(vecBytes);
+        })
+        .def("__bytes__", [](DiskProver &dp) {
+            std::vector<uint8_t> vecBytes = dp.ToBytes();
+            return py::bytes(reinterpret_cast<const char*>(vecBytes.data()), vecBytes.size());
+        })
         .def(
             "get_memo",
             [](DiskProver &dp) {

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -135,6 +135,17 @@ public:
         deserializer >> C2;
     }
 
+    DiskProver(DiskProver&& other) noexcept
+    {
+        std::lock_guard<std::mutex> lock(other._mtx);
+        filename = std::move(other.filename);
+        memo = std::move(other.memo);
+        id = std::move(other.id);
+        k = other.k;
+        table_begin_pointers = std::move(other.table_begin_pointers);
+        C2 = std::move(other.C2);
+    }
+
     ~DiskProver()
     {
         std::lock_guard<std::mutex> l(_mtx);
@@ -148,7 +159,11 @@ public:
 
     const std::vector<uint8_t>& GetId() { return id; }
 
-    std::string GetFilename() const noexcept { return filename; }
+    const std::vector<uint64_t>& GetTableBeginPointers() const noexcept { return table_begin_pointers; }
+
+    const std::vector<uint64_t>& GetC2() const noexcept { return C2; }
+
+    const std::string& GetFilename() const noexcept { return filename; }
 
     uint8_t GetSize() const noexcept { return k; }
 

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -33,6 +33,7 @@
 #include "calculate_bucket.hpp"
 #include "encoding.hpp"
 #include "entry_sizes.hpp"
+#include "serialize.hpp"
 #include "util.hpp"
 
 struct plot_header {
@@ -48,6 +49,7 @@ struct plot_header {
 // of space, for a given challenge.
 class DiskProver {
 public:
+    static const uint16_t VERSION{1};
     // The constructor opens the file, and reads the contents of the file header. The table pointers
     // will be used to find and seek to all seven tables, at the time of proving.
     explicit DiskProver(const std::string& filename) : id(kIdLen)
@@ -115,6 +117,22 @@ public:
         }
 
         delete[] c2_buf;
+    }
+
+    explicit DiskProver(const std::vector<uint8_t>& vecBytes)
+    {
+        Deserializer deserializer(vecBytes);
+        deserializer >> version;
+        if (version != VERSION) {
+            // TODO: Migrate to new version if we change something related to the data structure
+            throw std::invalid_argument("DiskProver: Invalid version.");
+        }
+        deserializer >> filename;
+        deserializer >> memo;
+        deserializer >> id;
+        deserializer >> k;
+        deserializer >> table_begin_pointers;
+        deserializer >> C2;
     }
 
     ~DiskProver()
@@ -233,7 +251,15 @@ public:
         return full_proof;
     }
 
+    std::vector<uint8_t> ToBytes() const
+    {
+        Serializer serializer;
+        serializer << version << filename << memo << id << k << table_begin_pointers << C2;
+        return serializer.Data();
+    }
+
 private:
+    uint16_t version{VERSION};
     mutable std::mutex _mtx;
     std::string filename;
     std::vector<uint8_t> memo;

--- a/src/serialize.hpp
+++ b/src/serialize.hpp
@@ -1,0 +1,151 @@
+// Copyright 2022 Chia Network Inc
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SRC_SERIALIZE_HPP_
+#define SRC_SERIALIZE_HPP_
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+template<typename Type> class Serializable{
+public:
+    static void SerializeImpl(const Type& in, std::vector<uint8_t>& out)
+    {
+        size_t nSize = sizeof(in);
+        out.reserve(out.size() + nSize);
+        for (size_t i = 0; i < nSize; ++i) {
+            out.push_back(*((uint8_t*)&in + i));
+        }
+    }
+    static size_t DeserializeImpl(const std::vector<uint8_t>& in, Type& out, size_t position)
+    {
+        size_t size = sizeof(out);
+        if (position + size > in.size()) {
+            throw std::invalid_argument("DeserializeImpl: Trying to read out of bounds.");
+        }
+        for (size_t i = 0; i < size; ++i) {
+            *((uint8_t*)&out + i) = in[position + i];
+        }
+        return size;
+    }
+};
+
+template<typename TypeIn, typename TypeOut>
+void Serialize(const TypeIn& in, TypeOut& out)
+{
+    Serializable<TypeIn>::SerializeImpl(in, out);
+}
+
+template<typename TypeIn, typename TypeOut>
+size_t Deserialize(const TypeIn& in, TypeOut& out, const size_t position)
+{
+    return Serializable<TypeOut>::DeserializeImpl(in, out, position);
+}
+
+template<typename TypeIn, typename TypeOut>
+void SerializeContainer(const TypeIn& in, TypeOut& out)
+{
+    Serialize(in.size(), out);
+    for (auto& entry : in) {
+        Serialize(entry, out);
+    }
+}
+
+template<typename TypeIn, typename TypeOut>
+size_t DeserializeContainer(const TypeIn& in, TypeOut& out, const size_t position)
+{
+    size_t elements;
+    size_t size = Deserialize(in, elements, position);
+    if (elements == 0) {
+        return size;
+    }
+    out.clear();
+    out.resize(elements);
+    for (size_t i = 0; i < elements; ++i) {
+        size += Deserialize(in, out[i], position + size);
+    }
+    return size;
+}
+
+template<typename Type>
+class Serializable<std::vector<Type>>{
+public:
+    static void SerializeImpl(const std::vector<Type>& in, std::vector<uint8_t>& out)
+    {
+        SerializeContainer(in, out);
+    }
+    static size_t DeserializeImpl(const std::vector<uint8_t>& in, std::vector<Type>& out, const size_t position)
+    {
+        return DeserializeContainer(in, out, position);
+    }
+};
+
+template<>
+class Serializable<std::string>{
+public:
+    static void SerializeImpl(const std::string& in, std::vector<uint8_t>& out)
+    {
+        SerializeContainer(in, out);
+    }
+    static size_t DeserializeImpl(const std::vector<uint8_t>& in, std::string& out, const size_t position)
+    {
+        return DeserializeContainer(in, out, position);
+    }
+};
+
+class Serializer
+{
+    std::vector<uint8_t> data;
+public:
+    template <typename InputType>
+    friend Serializer& operator <<(Serializer& serializer, const InputType& value) {
+        Serialize(value, serializer.data);
+        return serializer;
+    }
+    std::vector<uint8_t>& Data()
+    {
+        return data;
+    }
+    void Reset()
+    {
+        data.clear();
+    }
+};
+
+
+class Deserializer
+{
+    size_t position{0};
+    const std::vector<uint8_t>& data;
+public:
+    explicit Deserializer(const std::vector<uint8_t>& data) : data(data) {}
+    void Reset()
+    {
+        position = 0;
+    }
+    template <typename OutputType>
+    friend Deserializer& operator>>(Deserializer& deserializer, OutputType& output) {
+        deserializer.position += Deserialize(deserializer.data,
+                                             output,
+                                             deserializer.position);
+        return deserializer;
+    }
+    bool End() const
+    {
+        return position == data.size();
+    }
+};
+
+#endif  // SRC_SERIALIZE_HPP_

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -23,6 +23,7 @@
 #include "disk.hpp"
 #include "plotter_disk.hpp"
 #include "prover_disk.hpp"
+#include "serialize.hpp"
 #include "sort_manager.hpp"
 #include "verifier.hpp"
 
@@ -144,7 +145,87 @@ TEST_CASE("SliceInt64FromBytesFull")
     CHECK(Util::SliceInt64FromBytesFull(bytes, 7, 64) == ((0x1020304050607080ull << 3) | 0b100));
     CHECK(Util::SliceInt64FromBytesFull(bytes, 8, 64) == 0x0203040506070809ull);
 }
-
+TEST_CASE("(De)Serialization")
+{
+    Serializer serializer;
+    Deserializer deserializer(serializer.Data());
+    SECTION("Basics")
+    {
+        serializer.Reset();
+        for (uint8_t i = 0; i < 0xFF; ++i) {
+            serializer << i;
+        }
+        uint8_t n{0}, n_deserialized;
+        do{
+            deserializer >> n_deserialized;
+            REQUIRE(n_deserialized == n++);
+        } while (!deserializer.End());
+        serializer.Reset();
+        deserializer.Reset();
+        std::vector<float> vecFloat;
+        REQUIRE_THROWS(deserializer >> vecFloat); // Unexpected vector, leads to read out of bounds
+        float f = 0.123, f_deserialized = 0;
+        double d = 1.23, d_deserialized = 0;
+        int64_t i = -123, i_deserialized = 0;
+        uint64_t u = 123, u_deserialized = 0;
+        serializer << f;
+        deserializer >> f_deserialized;
+        REQUIRE(f_deserialized == f);
+        serializer << d;
+        deserializer >> d_deserialized;
+        REQUIRE(d_deserialized == d);
+        serializer << i;
+        deserializer >> i_deserialized;
+        REQUIRE(i_deserialized == i);
+        serializer << u;
+        deserializer >> u_deserialized;
+        REQUIRE(u_deserialized == u);
+        REQUIRE(deserializer.End());
+        deserializer.Reset();
+        deserializer >> f_deserialized;
+        deserializer >> d_deserialized;
+        deserializer >> i_deserialized;
+        deserializer >> u_deserialized;
+        REQUIRE(f_deserialized == f);
+        REQUIRE(d_deserialized == d);
+        REQUIRE(i_deserialized == i);
+        REQUIRE(u_deserialized == u);
+        REQUIRE(deserializer.End());
+        REQUIRE_THROWS(deserializer >> f_deserialized); // Read out of bounds
+    }
+    SECTION("vector")
+    {
+        std::vector<uint64_t> vec1{1,2,3}, vec2;
+        std::vector<std::vector<uint64_t>> vec3{{1}, {2,3}, {4,5,6}}, vec4;
+        serializer << vec1;
+        serializer << vec2;
+        serializer << vec3;
+        serializer << vec4;
+        std::vector<uint64_t> vec1_deserialized, vec2_deserialized;
+        std::vector<std::vector<uint64_t>> vec3_deserialized, vec4_deserialized;
+        deserializer >> vec1_deserialized;
+        deserializer >> vec2_deserialized;
+        deserializer >> vec3_deserialized;
+        deserializer >> vec4_deserialized;
+        REQUIRE(vec1_deserialized == vec1);
+        REQUIRE(vec2_deserialized == vec2);
+        REQUIRE(vec3_deserialized == vec3);
+        REQUIRE(vec4_deserialized == vec4);
+        REQUIRE(deserializer.End());
+    }
+    SECTION("string")
+    {
+        std::string str1 = "123", str2;
+        serializer << str1;
+        serializer << str2;
+        std::string str1_deserialized, str2_deserialized;
+        deserializer >> str1_deserialized;
+        deserializer >> str2_deserialized;
+        REQUIRE(str1_deserialized == str1);
+        REQUIRE(str2_deserialized == str2);
+        REQUIRE(deserializer.End());
+    }
+}
 TEST_CASE("Util")
 {
     SECTION("Increment and decrement")

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1075,6 +1075,38 @@ TEST_CASE("BufferedDisk")
     remove("test_file.bin");
 }
 
+TEST_CASE("DiskProver")
+{
+    SECTION("Move constructor")
+    {
+        std::string filename = "prover_test.plot";
+        DiskPlotter plotter = DiskPlotter();
+        std::vector<uint8_t> memo{1, 2, 3};
+        plotter.CreatePlotDisk(
+            ".", ".", ".", filename, 18, memo.data(),
+            memo.size(), plot_id_1, 32, 11, 0,
+            4000, 2);
+        DiskProver prover1(filename);
+        auto* p1_filename_ptr = prover1.GetFilename().data();
+        auto* p1_memo_ptr = prover1.GetMemo().data();
+        auto* p1_id_ptr = prover1.GetId().data();
+        auto* p1_table_begin_pointers_ptr = prover1.GetTableBeginPointers().data();
+        auto* p1_C2_ptr = prover1.GetC2().data();
+        DiskProver prover2(std::move(prover1));
+        REQUIRE(prover2.GetFilename().data() == p1_filename_ptr);
+        REQUIRE(prover2.GetMemo().data() == p1_memo_ptr);
+        REQUIRE(prover2.GetId().data() == p1_id_ptr);
+        REQUIRE(prover2.GetTableBeginPointers().data() == p1_table_begin_pointers_ptr);
+        REQUIRE(prover2.GetC2().data() == p1_C2_ptr);
+        REQUIRE(prover1.GetFilename().empty());
+        REQUIRE(prover1.GetMemo().empty());
+        REQUIRE(prover1.GetId().empty());
+        REQUIRE(prover1.GetSize() == prover1.GetSize());
+        REQUIRE(prover1.GetTableBeginPointers().empty());
+        REQUIRE(prover1.GetC2().empty());
+    }
+}
+
 TEST_CASE("FilteredDisk")
 {
     FileDisk d = FileDisk("test_file.bin");


### PR DESCRIPTION
This is a preparation to include `DiskProver` in the `PlotManager` cache in `chia-blockchain` (https://github.com/xdustinface/chia-blockchain/commit/1fdbb4399edd58ccc9c4c5816a364b5a551ea1f4).