### PR TITLE
include picosha2 in verifier.hpp

### DIFF
--- a/src/verifier.hpp
+++ b/src/verifier.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "calculate_bucket.hpp"
+#include "picosha2.hpp"
 
 class Verifier {
 public:


### PR DESCRIPTION
I'm running into some build issues locally: `Use of undeclared identifier 'picosha2'`. Could just be an issue with my environment but it seems like `picosha2.hpp` should be included to me.