### PR TITLE
Fixes race condition on prover_disk

### DIFF
--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -483,9 +483,10 @@ public:
                 req.plotId = id.data();
                 
                 GRResult res = grFetchProofForChallenge(gr, &req);
+                decompresser_context_queue.push(gr);
+
                 if (res != GRResult_OK) {
                     std::cout << "Got wrong result: " << static_cast<int>(res) << "\n";
-                    decompresser_context_queue.push(gr);
                     throw std::runtime_error("GRResult is not GRResult_OK.");
                 }
                 std::vector<Bits> uncompressed_xs;
@@ -493,7 +494,6 @@ public:
                     uncompressed_xs.push_back(Bits(req.fullProof[i], k));
                 }
                 xs = uncompressed_xs;
-                decompresser_context_queue.push(gr);
             }
 
             // Sorts them according to proof ordering, where


### PR DESCRIPTION
- Additional consistency changes around field naming on ContextQueue
- Added `dequeue_lock` on the `ContextQueue` to avoid race condition
- Avoid blocking decompressor context queue when requesting qualities