### PR TITLE
Rename instances of 'decompresser' to 'decompressor'

### DIFF
--- a/python-bindings/chiapos.cpp
+++ b/python-bindings/chiapos.cpp
@@ -183,7 +183,7 @@ PYBIND11_MODULE(chiapos, m)
 
     py::class_<ContextQueue>(m, "ContextQueue")
         .def("init", &ContextQueue::init);
-    m.attr("decompresser_context_queue") = &decompresser_context_queue;
+    m.attr("decompressor_context_queue") = &decompressor_context_queue;
 }
 
 #endif  // PYTHON_BINDINGS_PYTHON_BINDINGS_HPP_

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -70,7 +70,7 @@ inline void InitDecompresserQueueDefault(bool no_cuda = false)
     if (initialized) {
         return;
     }
-    decompresser_context_queue.init(1, (uint32_t)std::thread::hardware_concurrency(), false, 9, !no_cuda, 0, false);
+    decompressor_context_queue.init(1, (uint32_t)std::thread::hardware_concurrency(), false, 9, !no_cuda, 0, false);
     initialized = true;
 }
 

--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -278,7 +278,7 @@ public:
 };
 #endif // USE_GREEN_REAPER
 
-ContextQueue decompresser_context_queue;
+ContextQueue decompressor_context_queue;
 
 
 // The DiskProver, given a correctly formatted plot file, can efficiently generate valid proofs
@@ -600,11 +600,11 @@ public:
                             req.xLinePoints[1].lo = (uint64_t)alt_line_point;
                         }
 
-                        GreenReaperContext* gr = decompresser_context_queue.pop();
+                        GreenReaperContext* gr = decompressor_context_queue.pop();
                         assert(gr);
 
                         auto res = grGetFetchQualitiesXPair(gr, &req);
-                        decompresser_context_queue.push(gr);
+                        decompressor_context_queue.push(gr);
 
                         if (res != GRResult_OK) {
                             // Expect this will result in failure in a later step.
@@ -684,7 +684,7 @@ public:
 
             #if USE_GREEN_REAPER
                 if (compression_level > 0) {
-                    auto gr = decompresser_context_queue.pop();
+                    auto gr = decompressor_context_queue.pop();
 
                     GRCompressedProofRequest req{};
                     req.compressionLevel = compression_level;
@@ -696,7 +696,7 @@ public:
                     }
 
                     GRResult res = grFetchProofForChallenge(gr, &req);
-                    decompresser_context_queue.push(gr);
+                    decompressor_context_queue.push(gr);
 
                     if (res != GRResult_OK) {
                         if (res == GRResult_NoProof) {


### PR DESCRIPTION
Standardize around `decompressor` spelling