### PR TITLE
Update cibuildwheel to 2.11.2

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -149,7 +149,7 @@ jobs:
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: py.test -v {project}/tests
       run:
-        pipx run --spec='cibuildwheel==2.9.0' cibuildwheel --output-dir dist 2>&1
+        pipx run --spec='cibuildwheel==2.11.2' cibuildwheel --output-dir dist 2>&1
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Consolidate cibuildwheel version across repos to 2.11.2

This is the last version that uses bash in windows, which is needed for some scripts. The scripts could be edited to work in powershell, but this is left for another day