### PR TITLE
Move cibw config to pyproject.toml

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -132,46 +132,10 @@ jobs:
     - name: Build and test
       env:
         CIBW_PRERELEASE_PYTHONS: True
-        CIBW_BUILD_VERBOSITY_MACOS: 1
-        CIBW_BUILD_VERBOSITY_LINUX: 1
-        CIBW_BUILD_VERBOSITY_WINDOWS: 1
         CIBW_BUILD: ${{ matrix.python.cibw-build }}
-        CIBW_SKIP: '*-manylinux_i686 *-win32 *-musllinux_*'
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.python.manylinux['intel'] }}
-        CIBW_ENVIRONMENT_WINDOWS: "CP_USE_GREEN_REAPER=1"
-        CIBW_ENVIRONMENT_LINUX: CP_USE_GREEN_REAPER="1"
-        CIBW_BEFORE_ALL_LINUX: |
-          set -eo pipefail
-          set -x
-          # Get bladebit harvester
-          set -eo pipefail
-          ARCH=$(uname -m)
-          if [[ $ARCH == x86_64 ]]; then
-            .github/actions/fetch_bladebit_harvester.sh linux x86-64
-          else
-            .github/actions/fetch_bladebit_harvester.sh linux arm64
-          fi
-
-        CIBW_BEFORE_BUILD_LINUX: >
-          python -m pip install --upgrade pip
         CIBW_ARCHS_MACOS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
-        CIBW_BEFORE_ALL_MACOS: |
-          brew install gmp boost cmake
-          # Get bladebit harvester
-          set -eo pipefail
-          ARCH=$(uname -m)
-          if [[ $ARCH == x86_64 ]]; then
-            .github/actions/fetch_bladebit_harvester.sh macos x86-64
-          else
-            .github/actions/fetch_bladebit_harvester.sh macos arm64
-          fi
-
-        CIBW_BEFORE_BUILD_MACOS: >
-          python -m pip install --upgrade pip
-        CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.14 CP_USE_GREEN_REAPER=1"
-        CIBW_TEST_REQUIRES: pytest
-        CIBW_TEST_COMMAND: py.test -v {project}/tests
       run:
         pipx run --spec='cibuildwheel==2.11.2' cibuildwheel --output-dir dist 2>&1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,40 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+
+[tool.cibuildwheel]
+test-requires = "pytest"
+test-command = "py.test -v {project}/python-bindings/test.py"
+skip = "*-manylinux_i686 *-win32 *-musllinux_*"
+
+[tool.cibuildwheel.linux]
+build-verbosity = 1
+environment = {CP_USE_GREEN_REAPER=1}
+before-all = '''
+set -eo pipefail && set -x && set -eo pipefail && ARCH=$(uname -m)
+if [[ $ARCH == x86_64 ]]; then
+.github/actions/fetch_bladebit_harvester.sh linux x86-64
+else
+.github/actions/fetch_bladebit_harvester.sh linux arm64
+fi
+'''
+before-build = "python -m pip install --upgrade pip"
+
+[tool.cibuildwheel.macos]
+build-verbosity = 1
+before-all = '''
+brew install gmp boost cmake
+set -eo pipefail
+ARCH=$(uname -m)
+if [[ $ARCH == x86_64 ]]; then
+.github/actions/fetch_bladebit_harvester.sh macos x86-64
+else
+.github/actions/fetch_bladebit_harvester.sh macos arm64
+fi
+'''
+before-build = "python -m pip install --upgrade pip"
+environment = {MACOSX_DEPLOYMENT_TARGET="11", SYSTEM_VERSION_COMPAT=0, CP_USE_GREEN_REAPER=1}
+
+[tool.cibuildwheel.windows]
+build-verbosity = 1
+environment = "CP_USE_GREEN_REAPER=1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ local_scheme = "no-local-version"
 
 [tool.cibuildwheel]
 test-requires = "pytest"
-test-command = "py.test -v {project}/python-bindings/test.py"
+test-command = "pytest -v {project}/tests"
 skip = "*-manylinux_i686 *-win32 *-musllinux_*"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
Puts most `cibuildwheel` configuration into `pyproject.toml` instead of using envvars in the github actions.

The rationale is that this makes it a little bit easier to build the wheel locally for debugging and testing as there is less configuration specific to GH actions

Note some of the envvars refer to GH action matrix items, so those remain in the GH workflow.