### PR TITLE
Fix bug where timeout wasn't getting set for GPU harvesting

### DIFF
--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -127,6 +127,7 @@ public:
             }
         }
         cfg.gpuDeviceIndex = gpu_index;
+        this->context_queue_timeout = context_queue_timeout;
 
         for (uint32_t i = 0; i < context_count; i++) {
             
@@ -169,7 +170,7 @@ public:
                 }
             }
         }
-        this->context_queue_timeout = context_queue_timeout;
+
         return false;
     }
 


### PR DESCRIPTION
The context timeout was being set after the function was already returning for GPU harvesting. GPU harvesting was short-circuiting and returning before this was being set

Make sure to configure the timeout earlier