### PR TITLE
Actually run the tests on Windows using `RunTests`

### DIFF
--- a/.github/workflows/build-test-cplusplus.yml
+++ b/.github/workflows/build-test-cplusplus.yml
@@ -82,4 +82,4 @@ jobs:
         cd build-win
         cmake ..
         cmake --build . --config Release -j 6
-        ./RunTests
+        ./RunTests.exe

--- a/.github/workflows/build-test-cplusplus.yml
+++ b/.github/workflows/build-test-cplusplus.yml
@@ -82,4 +82,4 @@ jobs:
         cd build-win
         cmake ..
         cmake --build . --config Release -j 6
-        ctest -C Release -j 6
+        ./RunTests

--- a/.github/workflows/build-test-cplusplus.yml
+++ b/.github/workflows/build-test-cplusplus.yml
@@ -82,4 +82,4 @@ jobs:
         cd build-win
         cmake ..
         cmake --build . --config Release -j 6
-        ./RunTests.exe
+        .\Release\RunTests.exe


### PR DESCRIPTION
Windows was running the tests with `ctest` - this actually wasn't running any tests:

```
Test project D:/a/chiapos/chiapos/build-win
No tests were found!!!
```