### PR TITLE
Update catch2 to 3.5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ ENDIF()
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.3.2
+  GIT_TAG        v3.5.2
 )
 FetchContent_MakeAvailable(Catch2)
 


### PR DESCRIPTION
Update Catch2 to latest released version 3.5.2