### PR TITLE
Set `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` when building on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,9 @@ target_include_directories(uint128 PUBLIC uint128_t)
 
 target_compile_features(fse PUBLIC cxx_std_17)
 target_compile_features(chiapos PUBLIC cxx_std_17)
+if (WIN32)
+  target_compile_definitions(chiapos PUBLIC _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
 # target_compile_features(RunTests PUBLIC cxx_std_17)
 
 target_link_libraries(chiapos PRIVATE fse Threads::Threads

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,8 @@ target_include_directories(uint128 PUBLIC uint128_t)
 target_compile_features(fse PUBLIC cxx_std_17)
 target_compile_features(chiapos PUBLIC cxx_std_17)
 if (WIN32)
+  # workaround for constexpr mutex constructor change in MSVC 2022
+  # https://stackoverflow.com/questions/78598141/first-stdmutexlock-crashes-in-application-built-with-latest-visual-studio
   target_compile_definitions(chiapos PUBLIC _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 # target_compile_features(RunTests PUBLIC cxx_std_17)


### PR DESCRIPTION
There was a change in VS 2022 to make VS more compliant with the C++ standard and make std::mutex a constexpr.
However, this causes problems if an older version of the runtime is loaded first - in which case, the chiapos wheel will often crash.

https://stackoverflow.com/questions/78598141/first-stdmutexlock-crashes-in-application-built-with-latest-visual-studio

Set `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` in order to disable the newer (albeit more compliant) code and use the more compatible version