### PR TITLE
Link chiapos before blake3

### DIFF
--- a/rust-bindings/build.rs
+++ b/rust-bindings/build.rs
@@ -38,8 +38,8 @@ fn main() {
             .unwrap()
     );
 
-    println!("cargo:rustc-link-lib=static=blake3");
     println!("cargo:rustc-link-lib=static=chiapos_static");
+    println!("cargo:rustc-link-lib=static=blake3");
 
     let bindings = bindgen::Builder::default()
         .header(


### PR DESCRIPTION
make sure to put `-lchiapos_static` on the link line before `-lblake3` 

Jobs starting failing in newer ubuntu runner image - previous jobs succeeded using `Image: ubuntu-22.04 Version: 20240901.1.0` but are failing in `Image: ubuntu-22.04 Version: 20241015.1.0`

likely due to some update in clang or ld which is being somewhat more strict and or smarter on resolving static library dependencies in that the library the resolves the symbols should go after the library that uses it.