### PR TITLE
Add picosha.hpp to verifier.hpp

### DIFF
--- a/c-bindings/wrapper.h
+++ b/c-bindings/wrapper.h
@@ -1,5 +1,4 @@
 #include <stdint.h>
-#include "picosha2.hpp"
 
 extern "C" {
     bool validate_proof(const uint8_t* plot_id, uint8_t k, const uint8_t* challenge, const uint8_t* proof, uint16_t proof_len, uint8_t* quality_buf);

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -16,7 +16,6 @@
 #include <set>
 
 #include "cxxopts.hpp"
-#include "../lib/include/picosha2.hpp"
 #include "plotter_disk.hpp"
 #include "prover_disk.hpp"
 #include "verifier.hpp"

--- a/src/verifier.hpp
+++ b/src/verifier.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "calculate_bucket.hpp"
+#include "../lib/include/picosha2.hpp"
 
 class Verifier {
 public:

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -20,7 +20,6 @@
 #include <catch2/catch_session.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 
-#include "../lib/include/picosha2.hpp"
 #include "calculate_bucket.hpp"
 #include "disk.hpp"
 #include "plotter_disk.hpp"


### PR DESCRIPTION
`verifier.hpp` uses picosha2 but didn't include it, which seemed strange and required everywhere you used `verifier.hpp` to have also to include `picosha2.hpp`. This seems backwards.

Adjust `verifier.hpp` to include `picosha2.hpp` and remove now unneeded reference from other source files.