### PR TITLE
don't access proof after dropping gil

### DIFF
--- a/python-bindings/chiapos.cpp
+++ b/python-bindings/chiapos.cpp
@@ -165,11 +165,12 @@ PYBIND11_MODULE(chiapos, m)
 
                 std::string proof_str(proof);
                 const uint8_t *proof_ptr = reinterpret_cast<const uint8_t *>(proof_str.data());
+                auto proof_size = len(proof);
 
                 LargeBits quality;
                 {
                     py::gil_scoped_release release;
-                    quality = v.ValidateProof(seed_ptr, k, challenge_ptr, proof_ptr, len(proof));
+                    quality = v.ValidateProof(seed_ptr, k, challenge_ptr, proof_ptr, proof_size);
                 }
                 if (quality.GetSize() == 0) {
                     return stdx::optional<py::bytes>();

--- a/python-bindings/chiapos.cpp
+++ b/python-bindings/chiapos.cpp
@@ -165,7 +165,7 @@ PYBIND11_MODULE(chiapos, m)
 
                 std::string proof_str(proof);
                 const uint8_t *proof_ptr = reinterpret_cast<const uint8_t *>(proof_str.data());
-                auto proof_size = len(proof);
+                auto proof_size = proof_str.size();
 
                 LargeBits quality;
                 {


### PR DESCRIPTION
In `validate_proof` the `proof` variable is accessed after dropping the GIL. This can result in crashes as python may have released that memory at any time after the GIL is dropped.

Make sure to use a temp var to hold the proof size so we can avoid referencing this var