### PR TITLE
Remove python 3.8

### DIFF
--- a/.github/workflows/build-test-cplusplus.yml
+++ b/.github/workflows/build-test-cplusplus.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build-test-cplusplus.yml
+++ b/.github/workflows/build-test-cplusplus.yml
@@ -27,7 +27,7 @@ jobs:
           cmake -B ../build -DCMAKE_BUILD_TYPE=Debug -DWITH_COVERAGE=1
           cmake --build ../build -- -j 6
           ../build/RunTests
-          lcov -v --ignore-errors --directory ../build --capture --output-file lcov.info
+          lcov --directory ../build --capture --output-file lcov.info
           lcov --remove lcov.info '*_deps/*' '/usr/*' --output-file lcov.info
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/build-test-cplusplus.yml
+++ b/.github/workflows/build-test-cplusplus.yml
@@ -27,7 +27,7 @@ jobs:
           cmake -B ../build -DCMAKE_BUILD_TYPE=Debug -DWITH_COVERAGE=1
           cmake --build ../build -- -j 6
           ../build/RunTests
-          lcov --directory ../build --capture --output-file lcov.info
+          lcov -v --ignore-errors --directory ../build --capture --output-file lcov.info
           lcov --remove lcov.info '*_deps/*' '/usr/*' --output-file lcov.info
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/build-test-riscv64.yml
+++ b/.github/workflows/build-test-riscv64.yml
@@ -24,8 +24,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python:
-          - major-dot-minor: "3.8"
-            matrix: "3.8"
           - major-dot-minor: "3.9"
             matrix: "3.9"
           - major-dot-minor: "3.10"

--- a/.github/workflows/doc-html-pdf.yml
+++ b/.github/workflows/doc-html-pdf.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install python markdown
       shell: bash

--- a/.github/workflows/plot-k27-no-bitfield.yaml
+++ b/.github/workflows/plot-k27-no-bitfield.yaml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: cmake, Plot k=27
       run: |

--- a/.github/workflows/plot-k27.yaml
+++ b/.github/workflows/plot-k27.yaml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: cmake, Plot k=27
       run: |


### PR DESCRIPTION
Remove 3.8 for all workflows and matrices

Also use Ubuntu-22 for coverage task to avoid some as yet undiagnosed issue with `lcov` on `ubuntu-latest` which is now `ubuntu-24`
