### PR TITLE
update crate version to 2.0.9

### DIFF
--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chiapos"
-version = "2.0.8"
+version = "2.0.9"
 edition = "2021"
 license = "Apache-2.0"
 description = "Bindings to the chiapos C++ library."


### PR DESCRIPTION
Update crate to 2.0.9 in prep for new version of chiapos