### PR TITLE
Manually clear GNU_STACK executable bit on bladebit libraries

### DIFF
--- a/.github/actions/fetch_bladebit_harvester.sh
+++ b/.github/actions/fetch_bladebit_harvester.sh
@@ -89,7 +89,7 @@ if [[ "${artifact_ext}" == "zip" ]]; then
 else
   pushd "${dst_dir}"
   tar -xzvf "../../${artifact_name}"
-  if [[ "${host_os}" == "linux" ]] && [[${host_arch}" == "x86-64]]; then
+  if [[ "${host_os}" == "linux" ]] && [[ "${host_arch}" == "x86-64" ]]; then
     execstack -c lib/libbladebit_harvester.so
   fi
   popd

--- a/.github/actions/fetch_bladebit_harvester.sh
+++ b/.github/actions/fetch_bladebit_harvester.sh
@@ -89,5 +89,8 @@ if [[ "${artifact_ext}" == "zip" ]]; then
 else
   pushd "${dst_dir}"
   tar -xzvf "../../${artifact_name}"
+  if [[ "${host_os}" == "linux" ]] && [[${host_arch}" == "x86-64]]; then
+    execstack -c lib/libbladebit_harvester.so
+  fi
   popd
 fi

--- a/.github/actions/fetch_bladebit_harvester.sh
+++ b/.github/actions/fetch_bladebit_harvester.sh
@@ -67,7 +67,7 @@ esac
 
 # Download artifact
 artifact_name="green_reaper.${artifact_ext}"
-curl -L "${artifact_base_url}/green_reaper-${artifact_ver}-${host_os}-${host_arch}.${artifact_ext}" >"${artifact_name}"
+curl --ssl-revoke-best-effort -L "${artifact_base_url}/green_reaper-${artifact_ver}-${host_os}-${host_arch}.${artifact_ext}" >"${artifact_name}"
 
 # Validate sha256, if one was given
 if [ -n "${expected_sha256}" ]; then

--- a/.github/actions/fetch_bladebit_harvester.sh
+++ b/.github/actions/fetch_bladebit_harvester.sh
@@ -92,7 +92,11 @@ else
   pushd "${dst_dir}"
   tar -xzvf "../../${artifact_name}"
   if [[ "${host_os}" == "linux" ]] && [[ "${host_arch}" == "x86-64" ]]; then
-    # On linux clear the GNU_STACK executable bit for glibc 2.41 compat
+    # On Linux clear the GNU_STACK executable bit for glibc 2.41 compatability
+    # TODO: this should be removed when there is a new bladebit library
+    # that clears this explicitly during compiling/linking
+    # see https://github.com/Chia-Network/bladebit/pull/481
+    # and https://github.com/BLAKE3-team/BLAKE3/issues/109
     execstack -c lib/libbladebit_harvester.so
   fi
   popd

--- a/.github/actions/fetch_bladebit_harvester.sh
+++ b/.github/actions/fetch_bladebit_harvester.sh
@@ -40,6 +40,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   sha_bin="shasum -a 256"
 fi
 
+curlopts=""
 case "${host_os}" in
 linux)
   if [[ "${host_arch}" == "arm64" ]]; then
@@ -58,6 +59,7 @@ macos)
 windows)
   expected_sha256=$windows_sha256
   artifact_ext="zip"
+  curlopts="--ssl-revoke-best-effort"
   ;;
 *)
   echo >&2 "Unexpected OS '${host_os}'"
@@ -67,7 +69,7 @@ esac
 
 # Download artifact
 artifact_name="green_reaper.${artifact_ext}"
-curl -L "${artifact_base_url}/green_reaper-${artifact_ver}-${host_os}-${host_arch}.${artifact_ext}" >"${artifact_name}"
+curl ${curlopts} -L "${artifact_base_url}/green_reaper-${artifact_ver}-${host_os}-${host_arch}.${artifact_ext}" >"${artifact_name}"
 
 # Validate sha256, if one was given
 if [ -n "${expected_sha256}" ]; then

--- a/.github/actions/fetch_bladebit_harvester.sh
+++ b/.github/actions/fetch_bladebit_harvester.sh
@@ -90,6 +90,7 @@ else
   pushd "${dst_dir}"
   tar -xzvf "../../${artifact_name}"
   if [[ "${host_os}" == "linux" ]] && [[ "${host_arch}" == "x86-64" ]]; then
+    # On linux clear the GNU_STACK executable bit for glibc 2.41 compat
     execstack -c lib/libbladebit_harvester.so
   fi
   popd

--- a/.github/actions/fetch_bladebit_harvester.sh
+++ b/.github/actions/fetch_bladebit_harvester.sh
@@ -67,7 +67,7 @@ esac
 
 # Download artifact
 artifact_name="green_reaper.${artifact_ext}"
-curl --ssl-revoke-best-effort -L "${artifact_base_url}/green_reaper-${artifact_ver}-${host_os}-${host_arch}.${artifact_ext}" >"${artifact_name}"
+curl -L "${artifact_base_url}/green_reaper-${artifact_ver}-${host_os}-${host_arch}.${artifact_ext}" >"${artifact_name}"
 
 # Validate sha256, if one was given
 if [ -n "${expected_sha256}" ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ environment = {CP_USE_GREEN_REAPER=1}
 before-all = '''
 set -eo pipefail && set -x && set -eo pipefail && ARCH=$(uname -m)
 if [[ $ARCH == x86_64 ]]; then
-  dnf install execstack
+  dnf -y install execstack
   .github/actions/fetch_bladebit_harvester.sh linux x86-64
 else
   .github/actions/fetch_bladebit_harvester.sh linux arm64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ environment = {CP_USE_GREEN_REAPER=1}
 before-all = '''
 set -eo pipefail && set -x && set -eo pipefail && ARCH=$(uname -m)
 if [[ $ARCH == x86_64 ]]; then
+  dnf install execstack
   .github/actions/fetch_bladebit_harvester.sh linux x86-64
 else
   .github/actions/fetch_bladebit_harvester.sh linux arm64


### PR DESCRIPTION
Manually clear using `execstack -c` the GNU_STACK executable bit on the bladebit dynamic libraries after fetching the artifacts.

(also added `--ssl-revoke-best-effort` for windows to avoid bizarre CRL issues in CI. Probably some GH issue really)