### PR TITLE
List compile options separately

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,8 @@ add_library(fse ${FSE_FILES})
 
 IF (MSVC)
   add_compile_options(
-    "$<$<CONFIG:Release>:/O2 /Oy>"
+    "$<$<CONFIG:Release>:/O2>"
+    "$<$<CONFIG:Release>:/Oy>"
     "$<$<CONFIG:Debug>:/Ob1>"
     /Zi
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,10 +78,9 @@ add_library(fse ${FSE_FILES})
 
 IF (MSVC)
   add_compile_options(
-    $<$<COMPILE_LANGUAGE:C,CXX>:
-      $<$<CONFIG:Release>:/O2 /Oy>
-      $<$<CONFIG:Debug>:/Ob1>
-     >
+     $<$<COMPILE_LANGUAGE:C,CXX>:$<$<CONFIG:Release>:/O2>>
+     $<$<COMPILE_LANGUAGE:C,CXX>:$<$<CONFIG:Release>:/Oy>>
+     $<$<COMPILE_LANGUAGE:C,CXX>:$<$<CONFIG:Debug>:/Ob1>>
      /Zi
   )
 ELSE()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,9 +78,9 @@ add_library(fse ${FSE_FILES})
 
 IF (MSVC)
   add_compile_options(
-    "$<$<CONFIG:Release>:/O2>"
-    "$<$<CONFIG:Release>:/Oy>"
-    "$<$<CONFIG:Debug>:/Ob1>"
+    "$<$<COMPILE_LANGUAGE:C,CXX>$<$<CONFIG:Release>:/O2>"
+    "$<$<COMPILE_LANGUAGE:C,CXX>$<$<CONFIG:Release>:/Oy>"
+    "$<$<COMPILE_LANGUAGE:C,CXX>$<$<CONFIG:Debug>:/Ob1>"
     /Zi
   )
 ELSE()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,10 +78,11 @@ add_library(fse ${FSE_FILES})
 
 IF (MSVC)
   add_compile_options(
-    "$<$<COMPILE_LANGUAGE:C,CXX>$<$<CONFIG:Release>:/O2>"
-    "$<$<COMPILE_LANGUAGE:C,CXX>$<$<CONFIG:Release>:/Oy>"
-    "$<$<COMPILE_LANGUAGE:C,CXX>$<$<CONFIG:Debug>:/Ob1>"
-    /Zi
+    $<$<COMPILE_LANGUAGE:C,CXX>:
+      $<$<CONFIG:Release>:/O2 /Oy>
+      $<$<CONFIG:Debug>:/Ob1>
+     >
+     /Zi
   )
 ELSE()
   add_compile_options(


### PR DESCRIPTION
The previous cmake line: `"$<$<CONFIG:Release>:/O2 /Oy>"`

seemed to cause some strange errors :

```
cl : command line  warning D9002: ignoring unknown option '/O ' [D:\a\chiapos\chiapos\build-win\chiapos.vcxproj]
cl : command line  warning D9002: ignoring unknown option '/O/' [D:\a\chiapos\chiapos\build-win\chiapos.vcxproj]
cl : command line  warning D9002: ignoring unknown option '/OO' [D:\a\chiapos\chiapos\build-win\chiapos.vcxproj]
```

Listing them separately seemed to resolve this