### PR TITLE
[CHIA-4128 SEC-1034] Fix B17 sort manager uniform-sort fit check to use entry_size

### DIFF
--- a/src/b17sort_manager.hpp
+++ b/src/b17sort_manager.hpp
@@ -240,12 +240,10 @@ private:
         uint64_t bucket_entries = bucket_write_pointers[bucket_i] / this->entry_size;
         uint64_t entries_fit_in_memory = this->memory_size / this->entry_size;
 
-        uint32_t entry_len_memory = this->entry_size - this->begin_bits / 8;
-
         double have_ram = entry_size * entries_fit_in_memory / (1024.0 * 1024.0 * 1024.0);
         double qs_ram = entry_size * bucket_entries / (1024.0 * 1024.0 * 1024.0);
         double u_ram =
-            Util::RoundSize(bucket_entries) * entry_len_memory / (1024.0 * 1024.0 * 1024.0);
+            Util::RoundSize(bucket_entries) * entry_size / (1024.0 * 1024.0 * 1024.0);
 
         if (bucket_entries > entries_fit_in_memory) {
             throw InsufficientMemoryException(
@@ -257,9 +255,10 @@ private:
                            this->bucket_write_pointers[bucket_i + 1] == 0;
         bool force_quicksort = (quicksort == 1) || (quicksort == 2 && last_bucket);
         // Do SortInMemory algorithm if it fits in the memory
-        // (number of entries required * entry_len_memory) <= total memory available
+        // (number of entries required * entry_size) <= total memory available.
+        // entry_size matches what SortToMemory uses below, like the standard SortManager.
         if (!force_quicksort &&
-            Util::RoundSize(bucket_entries) * entry_len_memory <= this->memory_size) {
+            Util::RoundSize(bucket_entries) * this->entry_size <= this->memory_size) {
             std::cout << "\tBucket " << bucket_i << " uniform sort. Ram: " << std::fixed
                       << std::setprecision(3) << have_ram << "GiB, u_sort min: " << u_ram
                       << "GiB, qs min: " << qs_ram << "GiB." << std::endl;


### PR DESCRIPTION
## Summary

The legacy "Beta 17" sort manager (`src/b17sort_manager.hpp`) selected the in-memory uniform-sort path using a fit check based on `entry_len_memory` (`entry_size - begin_bits / 8`), but then called `UniformSort::SortToMemory` with the full `entry_size`. `SortToMemory` uses `RoundSize(num_entries) * entry_len` bytes of the caller's `memory_start` buffer (sized `memory_size`). Because the fit check used a smaller per-entry size than the sort itself, the two could disagree about how much memory the in-memory sort actually needs.

This change uses `entry_size` for the fit check, matching the standard `src/sort_manager.hpp`, which already uses `entry_size` consistently for both the fit check and the `SortToMemory` call. It also updates the `u_ram` ("u_sort min") log estimate to use `entry_size`, so the logged value matches both the real uniform-sort footprint and the fit-check threshold (previously the displayed estimate disagreed with the branch condition).

## Impact / risk

- Plotting-only, legacy disable-bitfield path. No wire protocol, RPC, DB schema, or on-disk plot-format change; the uniform and quicksort paths produce byte-identical sorted output, so only path selection / memory accounting is affected.
- No behavior change for current callers: all three `b17SortManager` constructions (`b17phase2.hpp`, `b17phase3.hpp` x2) pass `begin_bits = 0`, so `entry_len_memory == entry_size` already. This keeps the two sort managers aligned and correct for any future nonzero `begin_bits`.

## Testing

- Mirrors the already-validated standard `SortManager`; the changed comparison is type-identical (`uint16_t entry_size`, `uint64_t memory_size`).
- `b17SortManager` has no dedicated unit coverage today; this change brings its memory accounting in line with the standard `SortManager` path that the existing test suite already exercises.