### PR TITLE
prover_disk: validate plot k from header is within [kMinPlotSize, kMaxPlotSize]

### DIFF
--- a/src/prover_disk.hpp
+++ b/src/prover_disk.hpp
@@ -373,6 +373,17 @@ public:
         memcpy(id.data(), header.id, sizeof(header.id));
         this->k = header.k;
 
+        // `k` is read from the (untrusted) plot header. The proof verifier
+        // constrains it to [kMinPlotSize, kMaxPlotSize]; the prover must do the
+        // same. An out-of-range k from a malformed/crafted plot is otherwise
+        // propagated into fixed on-stack buffer sizing downstream
+        // (FxCalculator::CalculateBucket's 64-byte input_bytes), where a k >= 64
+        // overflows the buffer when the plot is loaded and challenged.
+        if (this->k < kMinPlotSize || this->k > kMaxPlotSize) {
+            throw std::invalid_argument(
+                "Invalid plot k size: " + std::to_string(this->k));
+        }
+
         uint8_t size_buf[2];
         SafeRead(disk_file, size_buf, 2);
         memo.resize(Util::TwoBytesToInt(size_buf));


### PR DESCRIPTION
## Summary
`DiskProver`'s header parser reads the plot size `k` from the plot header and stores it without a range check. Other consumers treat `k` as bounded — `Verifier::ValidateProof` already rejects `k < kMinPlotSize || k > kMaxPlotSize` — but the prover does not.

An out-of-range `k` from a malformed/crafted plot flows into fixed-size on-stack buffer sizing downstream: `FxCalculator::CalculateBucket` builds its `y1 + L + R` input into a 64-byte `input_bytes` stack buffer, which overflows for `k >= 64` when such a plot is loaded and a proof is computed.

## Change
Validate `k` against `[kMinPlotSize, kMaxPlotSize]` right after it is read from the header (covers both the on-disk `DiskProver(filename)` and `DiskProver::from_bytes` paths, which share `ReadHeaderInfo`), throwing `std::invalid_argument` like the other header checks in the same function.

## Impact / threat model
Low: plots are normally self-generated, so this requires loading an untrusted third-party plot. Submitted as a defensive hardening — happy to coordinate a CVE/credit if the maintainers consider it security-relevant.
