### PR TITLE
Align supported Python versions with chia-blockchain

### DIFF
--- a/.github/workflows/build-test-riscv64.yml
+++ b/.github/workflows/build-test-riscv64.yml
@@ -24,8 +24,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python:
-          - major-dot-minor: "3.9"
-            matrix: "3.9"
           - major-dot-minor: "3.10"
             matrix: "3.10"
           - major-dot-minor: "3.11"

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     author_email="mariano@chia.net",
     description="Chia proof of space plotting, proving, and verifying (wraps C++)",
     license="Apache-2.0",
-    python_requires=">=3.7",
+    python_requires=">=3.10, <4",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/Chia-Network/chiapos",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the Bugbot finding on #552: `setuptools_scm[toml]>=10.1.2` requires Python 3.10+, but chiapos still declared support for Python 3.7+ and tested Python 3.9 in the riscv64 workflow.

This PR aligns chiapos with [chia-blockchain's Python requirements](https://github.com/Chia-Network/chia-blockchain/blob/main/pyproject.toml) (`>=3.10, <4`).

## Changes

- Update `python_requires` in `setup.py` from `>=3.7` to `>=3.10, <4`
- Remove Python 3.9 from the riscv64 CI matrix in `.github/workflows/build-test-riscv64.yml`

## Context

Bugbot reported on PR #552 that requiring `setuptools_scm[toml]>=10.1.2` breaks builds on Python 3.7–3.9 because that version of setuptools-scm needs Python 3.10+. Since chia-blockchain already requires Python 3.10+, dropping older Python versions in chiapos is consistent with downstream usage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1984-3c3d-75fb-83bb-2d5f1eb70896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1984-3c3d-75fb-83bb-2d5f1eb70896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

