### PR TITLE
serialize: bound the declared container length against the remaining input

### DIFF
--- a/src/serialize.hpp
+++ b/src/serialize.hpp
@@ -73,6 +73,13 @@ size_t DeserializeContainer(const std::vector<uint8_t>& in, TypeOut& out, const 
     if (size == 0) {
         return offset;
     }
+    // Every element occupies at least one byte, so a declared element count larger
+    // than the number of bytes remaining can never be satisfied. Checking here keeps
+    // resize() from committing memory proportional to an untrusted length before the
+    // per-element reads below have a chance to fail.
+    if (size > in.size() - position - offset) {
+        throw std::invalid_argument("DeserializeContainer: declared size exceeds remaining input.");
+    }
     out.clear();
     out.resize(size);
     for (size_t i = 0; i < size; ++i) {


### PR DESCRIPTION
`DeserializeContainer` reads an element count out of the input and passes it straight to
`out.resize()` before any element has been read:

```cpp
size_t size;
size_t offset = Deserialize(in, size, position);
if (size == 0) { return offset; }
out.clear();
out.resize(size);                                   // <-- sized by the input's own claim
for (size_t i = 0; i < size; ++i) {
    offset += Deserialize(in, out[i], position + offset);
}
```

The per-element reads *are* bounds-checked — `Serializable<>::DeserializeImpl` throws
`"Trying to read out of bounds."` — so nothing is read past the end. But that check only fires
after the allocation has already happened.

### What I measured

Driving the unmodified `DiskProver(const std::vector<uint8_t>&)` with a blob built by chiapos's own
`Serializer`, patching only the `table_begin_pointers` length field:

```
declared         11  -> ACCEPTED                                      RSS peak    1 MB
declared 134217728  -> threw: Trying to read out of bounds.           RSS peak 1025 MB
declared 268435456  -> threw: Trying to read out of bounds.           RSS peak 2049 MB
declared       2^61 -> threw: vector (max_size)                       RSS peak    1 MB
declared         11  -> ACCEPTED                                      RSS peak    1 MB
```

A 185-byte input, and the response is linear in the declared number. The `2^61` row is the only
thing that stops it — `std::vector::max_size()` — which leaves everything below that honoured.

I re-ran the honest-length case afterwards so the 1 MB reading isn't an artefact of ordering.

### The change

One comparison before the resize. Every element occupies at least one byte, so a declared count
larger than the bytes remaining can never be satisfied — the bound is conservative and cannot
reject input that would otherwise have deserialized.

With the patch applied, the same probe:

```
declared         11  -> ACCEPTED                                                       RSS 1 MB
declared 134217728  -> threw: declared size exceeds remaining input                    RSS 1 MB
declared 268435456  -> threw: declared size exceeds remaining input                    RSS 1 MB
```

### Round-trips are preserved

I replicated the cases from `tests/test.cpp` (`:534-562`) against the patched header — including
the nested `std::vector<std::vector<uint64_t>>{{1},{2,3},{4,5,6}}`, the empty vector and string
cases, and the negative at `:502` where reading a vector out of a buffer that holds none must still
throw. All pass.

I could not run the full suite here — `cmake` wasn't available in my environment — so CI is the
real check on that.

### Where this is and isn't reachable

`DiskProver::from_bytes` is exposed to Python (`python-bindings/chiapos.cpp:80`) and reached by
`chia-blockchain` at `chia/plotting/cache.py:161`, which reads the harvester's local plot cache. So
the precondition is write access to that file rather than anything remote, and I'd rate this
robustness hardening rather than a vulnerability. I'm sending it because the fix is small and the
current behaviour is surprising, not because I think it's urgent.

### Prior art

Your Rust workspace already does exactly this. `chia_rs`'s `chia-traits/src/streamable.rs:132-133`
caps the preallocation at `min(2 MiB / size_of::<T>(), len)` and lets the vector grow as elements
actually parse, so a declared count of `u32::MAX` costs 2 MiB and one error rather than 16 GiB. This
PR is the same idea in the C++ deserializer, expressed as a bound rather than a cap because the
element size here isn't fixed.

Happy to adjust the wording of the error, use a different bound, or split it differently if you'd
prefer. Also glad to add a test case if you'd like one in `tests/test.cpp`.

---

Disclosure: this was found and prepared with AI assistance; every measurement above was run and the
numbers are from those runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared deserialization used for plot/cache byte blobs; the change reduces memory-exhaustion risk from malformed input but alters error timing/message for invalid declared lengths.
> 
> **Overview**
> **`DeserializeContainer`** now rejects a declared element count that exceeds the bytes still available in the buffer **before** calling **`out.resize(size)`**, throwing **`invalid_argument`** with a clear message instead of allocating proportional to a hostile length and failing later on per-element reads.
> 
> The check uses a conservative rule: each element needs at least one byte, so **`size > in.size() - position - offset`** cannot be valid. Honest serialized data is unchanged; only impossible counts are rejected earlier, with much lower peak memory on paths like **`DiskProver`** / plot cache deserialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01feb1dd031086ac84fb2c4cdb5353ab03a3a8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->